### PR TITLE
Expose NATS on shared Docker network

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -32,4 +32,10 @@ services:
     ports:
     - "4222:4222"
     - "8222:8222"
+    networks:
+    - default
+    - shared-nats
 
+networks:
+  shared-nats:
+    name: shared-nats


### PR DESCRIPTION
## Summary
- Add named `shared-nats` Docker network to NATS service in devcontainer compose
- Allows Pulse devcontainer to connect to this NATS instance for cross-container event streaming

## Test plan
- [ ] `docker compose up` starts NATS on both default and shared-nats networks
- [ ] Pulse devcontainer can reach NATS via the shared network

🤖 Generated with [Claude Code](https://claude.com/claude-code)