### PR TITLE
Add current stock price to NATS portfolio payloads

### DIFF
--- a/app/jobs/refresh_stocks_job.rb
+++ b/app/jobs/refresh_stocks_job.rb
@@ -10,5 +10,20 @@ class RefreshStocksJob < ApplicationJob
     result = FinancialDataService.refresh_stocks
     Rails.logger.info "RefreshStocksJob: Updated #{result[:updated]} stocks, #{result[:errors].size} errors"
     Rails.logger.warn "RefreshStocksJob: Failed symbols: #{result[:errors].join(', ')}" if result[:errors].any?
+
+    publish_portfolio_updates
+  end
+
+  private
+
+  def publish_portfolio_updates
+    User.where.not(portfolio_slug: nil).includes(holdings: :stock).find_each do |user|
+      NatsPublisher.publish("portfolio.updated", {
+        slug: user.portfolio_slug,
+        holdings: user.holdings.map { |h|
+          { symbol: h.stock.symbol, quantity: h.quantity.to_f, avg_price: h.average_price.to_f, price: (h.stock.price || 0).to_f }
+        }
+      })
+    end
   end
 end

--- a/app/models/holding.rb
+++ b/app/models/holding.rb
@@ -23,7 +23,7 @@ class Holding < ApplicationRecord
     NatsPublisher.publish("portfolio.updated", {
       slug: user.portfolio_slug,
       holdings: user.holdings.includes(:stock).map { |h|
-        { symbol: h.stock.symbol, quantity: h.quantity.to_f, avg_price: h.average_price.to_f }
+        { symbol: h.stock.symbol, quantity: h.quantity.to_f, avg_price: h.average_price.to_f, price: (h.stock.price || 0).to_f }
       }
     })
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,7 +36,7 @@ class User < ApplicationRecord
       NatsPublisher.publish("portfolio.opted_in", {
         slug: portfolio_slug,
         holdings: holdings.includes(:stock).map { |h|
-          { symbol: h.stock.symbol, quantity: h.quantity.to_f, avg_price: h.average_price.to_f }
+          { symbol: h.stock.symbol, quantity: h.quantity.to_f, avg_price: h.average_price.to_f, price: (h.stock.price || 0).to_f }
         }
       })
     else

--- a/spec/jobs/refresh_stocks_job_spec.rb
+++ b/spec/jobs/refresh_stocks_job_spec.rb
@@ -13,6 +13,34 @@ RSpec.describe RefreshStocksJob, type: :job do
         expect(FinancialDataService).to have_received(:refresh_stocks)
       end
 
+      it 'publishes portfolio updates for opted-in users after refresh' do
+        allow(FinancialDataService).to receive(:refresh_stocks).and_return({ updated: 1, errors: [] })
+
+        user = create(:user, portfolio_slug: 'test-refresh')
+        stock = create(:stock, price: 200.0)
+        create(:holding, user: user, stock: stock)
+
+        expect(NatsPublisher).to receive(:publish).with(
+          "portfolio.updated",
+          hash_including(
+            slug: 'test-refresh',
+            holdings: array_including(hash_including(price: 200.0))
+          )
+        )
+
+        described_class.perform_now
+      end
+
+      it 'does not publish for users without a portfolio slug' do
+        allow(FinancialDataService).to receive(:refresh_stocks).and_return({ updated: 1, errors: [] })
+
+        create(:user, portfolio_slug: nil)
+
+        expect(NatsPublisher).not_to receive(:publish)
+
+        described_class.perform_now
+      end
+
       it 'logs the result' do
         allow(FinancialDataService).to receive(:refresh_stocks).and_return({ updated: 3, errors: [ 'FAIL' ] })
         logger = ActiveSupport::Logger.new(nil)

--- a/spec/models/holding_spec.rb
+++ b/spec/models/holding_spec.rb
@@ -24,6 +24,17 @@ RSpec.describe Holding, type: :model do
       create(:holding, user: user, stock: stock)
     end
 
+    it 'includes price in the NATS payload' do
+      stock.update!(price: 150.0)
+
+      expect(NatsPublisher).to receive(:publish).with(
+        "portfolio.updated",
+        hash_including(holdings: array_including(hash_including(price: 150.0)))
+      )
+
+      create(:holding, user: user, stock: stock)
+    end
+
     it 'does not publish when user has no slug' do
       user_no_slug = create(:user)
       expect(NatsPublisher).not_to receive(:publish)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -48,6 +48,19 @@ RSpec.describe User, type: :model do
       user.update!(portfolio_slug: "my-slug")
     end
 
+    it 'includes price in opted_in payload' do
+      user = create(:user)
+      stock = create(:stock, price: 175.0)
+      create(:holding, user: user, stock: stock)
+
+      expect(NatsPublisher).to receive(:publish).with(
+        "portfolio.opted_in",
+        hash_including(holdings: array_including(hash_including(price: 175.0)))
+      )
+
+      user.update!(portfolio_slug: "price-slug")
+    end
+
     it 'publishes portfolio.opted_out when slug is cleared' do
       user = create(:user, portfolio_slug: "old-slug")
       expect(NatsPublisher).to receive(:publish).with("portfolio.opted_out", hash_including(slug: "old-slug"))


### PR DESCRIPTION
## Summary
- Add `price` field to NATS holdings payloads in `Holding`, `User`, and `RefreshStocksJob`
- Re-publish all opted-in portfolios after stock price refresh so Pulse allocations stay current
- Pulse companion PR: fleveque/pulse#26

## Test plan
- [x] `bundle exec rspec` — 355 examples, 0 failures
- [x] `bin/rubocop` — no offenses
- [x] `npx tsc --noEmit` — clean
- [ ] Deploy Rails first, then Pulse
- [ ] Verify Pulse portfolio percentages reflect market value

🤖 Generated with [Claude Code](https://claude.com/claude-code)