### PR TITLE
Migrate deploy secrets to 1Password

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -9,6 +9,10 @@ services:
     volumes:
     - ../..:/workspaces:cached
 
+    # App config / secrets for local dev (gitignored .env in the repo root).
+    env_file:
+    - ../.env
+
     # Overrides default command so things don't shut down after the process ends.
     command: sleep infinity
 

--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,34 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/common-utils:2": {
+      "version": "2.5.8",
+      "resolved": "ghcr.io/devcontainers/features/common-utils@sha256:c42fdefe6d737a3a6f61cc52b23c7c9a565d08cc4d9c303669a7cf2ee5fd81fc",
+      "integrity": "sha256:c42fdefe6d737a3a6f61cc52b23c7c9a565d08cc4d9c303669a7cf2ee5fd81fc"
+    },
+    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {
+      "version": "1.9.1",
+      "resolved": "ghcr.io/devcontainers/features/docker-outside-of-docker@sha256:dc89605f01ff2f24252c61f7c8ba2a58ccdbc14f2ebf87a7952d9e2b89834850",
+      "integrity": "sha256:dc89605f01ff2f24252c61f7c8ba2a58ccdbc14f2ebf87a7952d9e2b89834850"
+    },
+    "ghcr.io/devcontainers/features/github-cli:1": {
+      "version": "1.1.0",
+      "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
+      "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
+    },
+    "ghcr.io/devcontainers/features/node:1": {
+      "version": "1.7.1",
+      "resolved": "ghcr.io/devcontainers/features/node@sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6",
+      "integrity": "sha256:8c0de46939b61958041700ee89e3493f3b2e4131a06dc46b4d9423427d06e5f6"
+    },
+    "ghcr.io/rails/devcontainer/features/activestorage": {
+      "version": "1.1.1",
+      "resolved": "ghcr.io/rails/devcontainer/features/activestorage@sha256:7fa8fff898ac33076ebf65631d3c6c902dc9bad87de3e5dfa645f3e2d7a35c07",
+      "integrity": "sha256:7fa8fff898ac33076ebf65631d3c6c902dc9bad87de3e5dfa645f3e2d7a35c07"
+    },
+    "ghcr.io/rails/devcontainer/features/sqlite3": {
+      "version": "1.0.0",
+      "resolved": "ghcr.io/rails/devcontainer/features/sqlite3@sha256:fa4a12e87152158ed9b67acb819ad2e1bd78c7e3808ff08e786a76a677af2c58",
+      "integrity": "sha256:fa4a12e87152158ed9b67acb819ad2e1bd78c7e3808ff08e786a76a677af2c58"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,7 +28,6 @@
   "containerEnv": {
     "CAPYBARA_SERVER_PORT": "45678",
     "SELENIUM_HOST": "selenium",
-    "KAMAL_REGISTRY_PASSWORD": "$KAMAL_REGISTRY_PASSWORD",
     "VITE_RUBY_HOST": "0.0.0.0",
     "NATS_URL": "nats://nats:4222"
   },

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,13 +17,12 @@ jobs:
 
     env:
       DOCKER_BUILDKIT: 1
-      KAMAL_REGISTRY_PASSWORD: ${{ secrets.KAMAL_REGISTRY_PASSWORD }}
-      RAILS_MASTER_KEY: ${{ secrets.RAILS_MASTER_KEY }}
-      GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
-      GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
-      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-      VITE_LOGO_SERVICE_URL: ${{ secrets.VITE_LOGO_SERVICE_URL }}
-      VITE_LOGO_SERVICE_API_KEY: ${{ secrets.VITE_LOGO_SERVICE_API_KEY }}
+      # All deploy secrets are pulled from 1Password by .kamal/secrets.
+      # OP_SERVICE_ACCOUNT_TOKEN is the only secret; OP_ACCOUNT/OP_VAULT are
+      # plain config that .kamal/secrets interpolates.
+      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+      OP_ACCOUNT: my.1password.com
+      OP_VAULT: quantic-prod
 
     steps:
       - name: Checkout code
@@ -37,6 +36,9 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
+      - name: Install 1Password CLI
+        uses: 1password/install-cli-action@v1
+
       - name: Set up SSH agent
         uses: webfactory/ssh-agent@v0.9.0
         with:
@@ -45,9 +47,6 @@ jobs:
       - name: Add server to known hosts
         run: |
           ssh-keyscan 46.224.239.228 >> ~/.ssh/known_hosts 2>/dev/null
-
-      - name: Write master key for Kamal secrets
-        run: echo -n "$RAILS_MASTER_KEY" > config/master.key
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
           bundler-cache: true
 
       - name: Install 1Password CLI
-        uses: 1password/install-cli-action@v1
+        uses: 1password/install-cli-action@v3
 
       - name: Set up SSH agent
         uses: webfactory/ssh-agent@v0.9.0

--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -1,28 +1,18 @@
-# Secrets defined here are available for reference under registry/password, env/secret, builder/secrets,
-# and accessories/*/env/secret in config/deploy.yml. All secrets should be pulled from either
-# password manager, ENV, or a file. DO NOT ENTER RAW CREDENTIALS HERE! This file needs to be safe for git.
+# Secrets for Kamal deployment — sourced from 1Password.
+#
+# Requires OP_SERVICE_ACCOUNT_TOKEN, OP_ACCOUNT, OP_VAULT in the shell env
+# (local: repo .env via direnv; CI: deploy.yml env block).
+#
+# Parsed by dotenv line-by-line (NOT bash): each $(...) must stay on one line,
+# and only ${VAR} interpolation is supported (no ${VAR:-default}).
 
-# Example of extracting secrets from 1password (or another compatible pw manager)
-# SECRETS=$(kamal secrets fetch --adapter 1password --account your-account --from Vault/Item KAMAL_REGISTRY_PASSWORD RAILS_MASTER_KEY)
-# KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD ${SECRETS})
-# RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY ${SECRETS})
+REGISTRY=$(kamal secrets fetch --adapter 1password --account ${OP_ACCOUNT} --from ${OP_VAULT}/registry KAMAL_REGISTRY_PASSWORD)
+DP=$(kamal secrets fetch --adapter 1password --account ${OP_ACCOUNT} --from ${OP_VAULT}/dividend-portfolio RAILS_MASTER_KEY GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GEMINI_API_KEY VITE_LOGO_SERVICE_URL VITE_LOGO_SERVICE_API_KEY)
 
-# Use a GITHUB_TOKEN if private repositories are needed for the image
-# GITHUB_TOKEN=$(gh config get -h github.com oauth_token)
-
-# Grab the registry password from ENV
-KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
-
-# Improve security by using a password manager. Never check config/master.key into git!
-RAILS_MASTER_KEY=$(cat config/master.key)
-
-# Google OAuth - from environment variables on deploy machine
-GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID
-GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET
-
-# Google Gemini AI - from environment variables on deploy machine
-GEMINI_API_KEY=$GEMINI_API_KEY
-
-# Logo service (self-hosted) - build-time secrets baked into Vite frontend
-VITE_LOGO_SERVICE_URL=$VITE_LOGO_SERVICE_URL
-VITE_LOGO_SERVICE_API_KEY=$VITE_LOGO_SERVICE_API_KEY
+KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD ${REGISTRY})
+RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY ${DP})
+GOOGLE_CLIENT_ID=$(kamal secrets extract GOOGLE_CLIENT_ID ${DP})
+GOOGLE_CLIENT_SECRET=$(kamal secrets extract GOOGLE_CLIENT_SECRET ${DP})
+GEMINI_API_KEY=$(kamal secrets extract GEMINI_API_KEY ${DP})
+VITE_LOGO_SERVICE_URL=$(kamal secrets extract VITE_LOGO_SERVICE_URL ${DP})
+VITE_LOGO_SERVICE_API_KEY=$(kamal secrets extract VITE_LOGO_SERVICE_API_KEY ${DP})

--- a/.kamal/secrets.beta
+++ b/.kamal/secrets.beta
@@ -1,17 +1,19 @@
-# Secrets for beta destination
-# CI writes config/master.key from the RAILS_MASTER_KEY secret before deploy
+# Secrets for the beta destination — sourced from 1Password.
+#
+# Requires OP_SERVICE_ACCOUNT_TOKEN, OP_ACCOUNT, OP_VAULT in the shell env
+# (local: repo .env via direnv; CI: deploy.yml env block). Beta shares prod
+# secret values; deploy.beta.yml only overrides env.clear/proxy/volumes.
+#
+# Parsed by dotenv line-by-line (NOT bash): each $(...) must stay on one line,
+# and only ${VAR} interpolation is supported (no ${VAR:-default}).
 
-KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
+REGISTRY=$(kamal secrets fetch --adapter 1password --account ${OP_ACCOUNT} --from ${OP_VAULT}/registry KAMAL_REGISTRY_PASSWORD)
+DP=$(kamal secrets fetch --adapter 1password --account ${OP_ACCOUNT} --from ${OP_VAULT}/dividend-portfolio RAILS_MASTER_KEY GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GEMINI_API_KEY VITE_LOGO_SERVICE_URL VITE_LOGO_SERVICE_API_KEY)
 
-RAILS_MASTER_KEY=$(cat config/master.key)
-
-# Google OAuth
-GOOGLE_CLIENT_ID=$GOOGLE_CLIENT_ID
-GOOGLE_CLIENT_SECRET=$GOOGLE_CLIENT_SECRET
-
-# Google Gemini AI
-GEMINI_API_KEY=$GEMINI_API_KEY
-
-# Logo service (self-hosted) - build-time secrets baked into Vite frontend
-VITE_LOGO_SERVICE_URL=$VITE_LOGO_SERVICE_URL
-VITE_LOGO_SERVICE_API_KEY=$VITE_LOGO_SERVICE_API_KEY
+KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD ${REGISTRY})
+RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY ${DP})
+GOOGLE_CLIENT_ID=$(kamal secrets extract GOOGLE_CLIENT_ID ${DP})
+GOOGLE_CLIENT_SECRET=$(kamal secrets extract GOOGLE_CLIENT_SECRET ${DP})
+GEMINI_API_KEY=$(kamal secrets extract GEMINI_API_KEY ${DP})
+VITE_LOGO_SERVICE_URL=$(kamal secrets extract VITE_LOGO_SERVICE_URL ${DP})
+VITE_LOGO_SERVICE_API_KEY=$(kamal secrets extract VITE_LOGO_SERVICE_API_KEY ${DP})

--- a/README.md
+++ b/README.md
@@ -225,17 +225,25 @@ If you fork this project, update these files with your own server, domains, and 
 
 - `config/deploy.yml` — production server IP, domains, and container registry
 - `config/deploy.beta.yml` — beta domain
-- `.kamal/secrets` and `.kamal/secrets.beta` — secret references (no raw values)
+- `.kamal/secrets` and `.kamal/secrets.beta` — fetch secrets from 1Password (no raw values)
 
-Then add these GitHub Actions secrets to your repository:
+Deploy secrets live in a 1Password vault and are pulled at deploy time by `.kamal/secrets`
+via `kamal secrets fetch --adapter 1password`. The only GitHub Actions secrets you need:
 
 | Secret | Description |
 |---|---|
 | `SSH_PRIVATE_KEY` | SSH key authorized on your server |
-| `KAMAL_REGISTRY_PASSWORD` | Container registry token (e.g. GHCR PAT with `packages:write`) |
-| `RAILS_MASTER_KEY` | Contents of `config/master.key` |
-| `GOOGLE_CLIENT_ID` | Google OAuth client ID |
-| `GOOGLE_CLIENT_SECRET` | Google OAuth client secret |
-| `GEMINI_API_KEY` | Google Gemini API key (optional) |
-| `VITE_LOGO_SERVICE_URL` | Logo service URL (optional) |
-| `VITE_LOGO_SERVICE_API_KEY` | Logo service API key (optional) |
+| `OP_SERVICE_ACCOUNT_TOKEN` | 1Password service account token — `.kamal/secrets` uses it to fetch all other secrets |
+
+`.github/workflows/deploy.yml` also sets two plain (non-secret) env values — `OP_ACCOUNT` and
+`OP_VAULT` — that select the 1Password account and vault.
+
+#### Local development
+
+Copy the sample files and fill in your values (both are gitignored; `direnv` loads `.env`):
+
+```
+cp env.sample .env       # fill in OP_SERVICE_ACCOUNT_TOKEN + dev config
+cp envrc.sample .envrc
+direnv allow
+```

--- a/env.sample
+++ b/env.sample
@@ -1,3 +1,14 @@
+# Copy to .env (gitignored) and fill in. Loaded by direnv via .envrc.
+
+# === Deploy bootstrap (1Password) ===
+# All deploy secrets are pulled from 1Password by .kamal/secrets. These three
+# values are the only ones you set yourself.
+OP_SERVICE_ACCOUNT_TOKEN=your_1password_service_account_token
+OP_ACCOUNT=my.1password.com
+OP_VAULT=quantic-prod
+
+# === Local dev app config ===
+
 # Financial data providers API keys
 ALPHAVANTAGE_API_KEY=your_alphavantage_api_key
 
@@ -9,11 +20,12 @@ VITE_LOGO_SERVICE_URL=https://logos.quantic.es
 VITE_LOGO_SERVICE_API_KEY=your_logo_service_api_key
 
 # NATS (for Pulse real-time event integration)
-NATS_URL=nats://pulse-nats-1:4222
+NATS_URL=nats://nats:4222
 
 # Stock refresh schedule (optional - for periodic background refresh)
 # Uses Solid Queue recurring format, e.g. "every 4 hours", "every 30 minutes"
-STOCK_REFRESH_SCHEDULE=every 24 hours
+# Quote the value — direnv's dotenv parser rejects unquoted spaces.
+STOCK_REFRESH_SCHEDULE="every 24 hours"
 
 # Google OAuth (optional - for "Sign in with Google")
 # Get credentials at https://console.cloud.google.com/apis/credentials
@@ -23,6 +35,3 @@ GOOGLE_CLIENT_SECRET=your_google_client_secret
 
 # Google Gemini AI (for AI portfolio insights — optional)
 GEMINI_API_KEY=your_gemini_api_key
-
-# Container registry (Kamal deployment)
-KAMAL_REGISTRY_PASSWORD=your_registry_token

--- a/envrc.sample
+++ b/envrc.sample
@@ -1,0 +1,4 @@
+# Copy to .envrc, then run: direnv allow
+# Loads .env (see env.sample) into the shell — needed for kamal commands
+# (OP_SERVICE_ACCOUNT_TOKEN) and local dev config.
+dotenv

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "dividend-portfolio",
       "dependencies": {
         "@tanstack/react-query": "^5.90.20",
         "class-variance-authority": "^0.7.1",
@@ -3779,9 +3780,9 @@
       }
     },
     "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
-      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -3828,9 +3829,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3887,9 +3888,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "funding": [
         {
           "type": "opencollective",
@@ -4443,9 +4444,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.3.tgz",
+      "integrity": "sha512-/4XH147Ui7OGTjg3HbdWe5arnZQSbfuRzdr9Ec7TQi5I7R+ir0Rlc9GIvD4v0XZurELqA035KVXJXpR61xhiTA==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",


### PR DESCRIPTION
## Summary
- Deploy secrets now pulled from the `quantic-prod` 1Password vault by `.kamal/secrets` / `.kamal/secrets.beta` via `kamal secrets fetch`, replacing ~10 individual env vars / GitHub Actions secrets. Only `OP_SERVICE_ACCOUNT_TOKEN` is needed (plus plain `OP_ACCOUNT` / `OP_VAULT` config).
- CI `deploy.yml` updated: installs the 1Password CLI, passes the single token.
- Devcontainer now loads `../.env` via `env_file`; stale `KAMAL_REGISTRY_PASSWORD` dropped from `containerEnv`.
- README, `env.sample`, and new `envrc.sample` updated for the new setup.

## Test plan
- [x] `kamal secrets print` and `kamal secrets print -d beta` resolve all values
- [x] Local `kamal deploy -d beta` succeeds
- [ ] CI beta deploy green (push to `beta` branch)
- [ ] CI prod deploy green (merge to `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)