### PR TITLE
Multi-currency phase 2: FX rates + preferred currency + displayTotal

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem "timecop"
 gem "simplecov", require: false, group: :test
 
 # Financial data providers (You can just pick one and comment out the others)
-gem "yahoo_finance_client", "~> 0.6.0"
+gem "yahoo_finance_client", "~> 0.7.0"
 gem "alphavantage"
 
 # NATS messaging

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -469,7 +469,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yahoo_finance_client (0.6.0)
+    yahoo_finance_client (0.7.0)
       csv
       httparty (~> 0.21.0)
     zeitwerk (2.7.3)
@@ -518,7 +518,7 @@ DEPENDENCIES
   tzinfo-data
   vite_rails
   web-console
-  yahoo_finance_client (~> 0.6.0)
+  yahoo_finance_client (~> 0.7.0)
 
 BUNDLED WITH
    2.6.2

--- a/app/controllers/api/v1/buy_plans_controller.rb
+++ b/app/controllers/api/v1/buy_plans_controller.rb
@@ -51,13 +51,36 @@ module Api
         total_items = items.sum { |i| i[:quantity] }
         totals = Hash.new(0.0)
         items.each { |i| totals[i[:currency]] += i[:subtotal] if i[:subtotal] }
+        totals_by_currency = totals.transform_values(&:to_f)
 
         {
           id: buy_plan.id,
           items: items,
           totalItems: total_items,
-          totalsByCurrency: totals.transform_values(&:to_f)
+          totalsByCurrency: totals_by_currency,
+          displayTotal: cart_display_total(totals_by_currency)
         }
+      end
+
+      def cart_display_total(totals_by_currency)
+        preferred = Current.user.preferred_currency
+        conversions = {}
+        total = 0.0
+
+        totals_by_currency.each do |currency, amount|
+          if currency == preferred
+            total += amount
+            next
+          end
+
+          rate = FxRateService.rate(from: currency, to: preferred)
+          return nil unless rate
+
+          conversions[currency] = rate
+          total += amount * rate
+        end
+
+        { currency: preferred, total: total.to_f, conversions: conversions }
       end
 
       def serialize_item(item)

--- a/app/controllers/api/v1/holdings_controller.rb
+++ b/app/controllers/api/v1/holdings_controller.rb
@@ -24,7 +24,8 @@ module Api
 
         render_success({
           holdings: serialized,
-          totalsByCurrency: totals_by_currency_payload(totals)
+          totalsByCurrency: totals_by_currency_payload(totals),
+          displayTotal: display_total_payload(totals)
         })
       end
 
@@ -93,7 +94,7 @@ module Api
       def insights
         holdings = Current.user.holdings.includes(:stock)
         stocks_data = holdings.map { |h| serialize_stock_for_ai(h.stock) }
-        result = AiInsightsService.portfolio_insights(stocks_data, locale: params[:locale])
+        result = AiInsightsService.portfolio_insights(stocks_data, locale: params[:locale], preferred_currency: Current.user.preferred_currency)
         render_success(result)
       rescue AiProviders::BaseProvider::AiError => e
         Rails.logger.error "AI portfolio insights error: #{e.message}"
@@ -104,6 +105,44 @@ module Api
 
       def set_holding
         @holding = Current.user.holdings.find(params[:id])
+      end
+
+      # Single converted total in the user's preferred currency. Returns nil if any
+      # required FX rate is unavailable so the frontend can fall back to per-currency rows.
+      def display_total_payload(totals)
+        preferred = Current.user.preferred_currency
+        conversions = {}
+        total_value = 0.0
+        total_cost = 0.0
+
+        totals.each do |currency, t|
+          if currency == preferred
+            total_value += t[:value]
+            total_cost += t[:cost]
+            next
+          end
+
+          rate = FxRateService.rate(from: currency, to: preferred)
+          return nil unless rate
+
+          conversions[currency] = rate
+          total_value += t[:value] * rate
+          total_cost += t[:cost] * rate
+        end
+
+        build_display_total(preferred, total_value, total_cost, conversions)
+      end
+
+      def build_display_total(currency, value, cost, conversions)
+        gain_loss = value - cost
+        {
+          currency: currency,
+          value: value.to_f,
+          cost: cost.to_f,
+          gainLoss: gain_loss.to_f,
+          gainLossPercent: cost > 0 ? (gain_loss / cost * 100).to_f : 0.0,
+          conversions: conversions
+        }
       end
 
       def totals_by_currency_payload(totals)

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -3,21 +3,13 @@ module Api
     class ProfilesController < BaseController
       # GET /api/v1/profile
       def show
-        render_success({
-          id: Current.user.id,
-          emailAddress: Current.user.email_address,
-          portfolioSlug: Current.user.portfolio_slug
-        })
+        render_success(serialize_profile)
       end
 
       # PATCH /api/v1/profile
       def update
         if Current.user.update(profile_params)
-          render_success({
-            id: Current.user.id,
-            emailAddress: Current.user.email_address,
-            portfolioSlug: Current.user.portfolio_slug
-          })
+          render_success(serialize_profile)
         else
           render_error(Current.user.errors.full_messages.join(", "))
         end
@@ -25,9 +17,18 @@ module Api
 
       private
 
+      def serialize_profile
+        {
+          id: Current.user.id,
+          emailAddress: Current.user.email_address,
+          portfolioSlug: Current.user.portfolio_slug,
+          preferredCurrency: Current.user.preferred_currency
+        }
+      end
+
       def profile_params
-        permitted = params.permit(:portfolio_slug)
-        permitted[:portfolio_slug] = nil if permitted[:portfolio_slug].blank?
+        permitted = params.permit(:portfolio_slug, :preferred_currency)
+        permitted[:portfolio_slug] = nil if permitted.key?(:portfolio_slug) && permitted[:portfolio_slug].blank?
         permitted
       end
     end

--- a/app/controllers/api/v1/radars_controller.rb
+++ b/app/controllers/api/v1/radars_controller.rb
@@ -42,7 +42,7 @@ module Api
       def insights
         stocks = @radar.sorted_stocks || []
         stocks_data = stocks.map { |s| serialize_stock_for_ai(s) }
-        result = AiInsightsService.radar_insights(stocks_data, locale: params[:locale])
+        result = AiInsightsService.radar_insights(stocks_data, locale: params[:locale], preferred_currency: Current.user.preferred_currency)
         render_success(result)
       rescue AiProviders::BaseProvider::AiError => e
         Rails.logger.error "AI insights error: #{e.message}"

--- a/app/controllers/api/v1/stocks_controller.rb
+++ b/app/controllers/api/v1/stocks_controller.rb
@@ -83,7 +83,7 @@ module Api
           updated_at: stock.updated_at.to_i
         }
 
-        result = AiInsightsService.stock_summary(stock_data, locale: params[:locale])
+        result = AiInsightsService.stock_summary(stock_data, locale: params[:locale], preferred_currency: Current.user.preferred_currency)
         render_success(result)
       rescue AiProviders::BaseProvider::AiError => e
         Rails.logger.error "AI summary error for stock #{params[:id]}: #{e.message}"

--- a/app/frontend/hooks/useProfileQueries.ts
+++ b/app/frontend/hooks/useProfileQueries.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { profileApi } from '../lib/api'
+import { profileApi, type ProfileUpdate } from '../lib/api'
 
 export function useProfile() {
   return useQuery({
@@ -13,10 +13,12 @@ export function useUpdateProfile() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: (portfolioSlug: string | null) => profileApi.update(portfolioSlug),
+    mutationFn: (update: ProfileUpdate) => profileApi.update(update),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['profile'] })
       queryClient.invalidateQueries({ queryKey: ['session'] })
+      queryClient.invalidateQueries({ queryKey: ['holdings'] })
+      queryClient.invalidateQueries({ queryKey: ['buyPlan'] })
     },
   })
 }

--- a/app/frontend/lib/api.ts
+++ b/app/frontend/lib/api.ts
@@ -283,14 +283,23 @@ export const holdingsApi = {
 // Profile API - Authenticated endpoints (user settings)
 // ============================================================================
 
+export interface ProfileUpdate {
+  portfolioSlug?: string | null
+  preferredCurrency?: string
+}
+
 export const profileApi = {
   get: () => apiFetch<UserProfile>('/profile'),
 
-  update: (portfolioSlug: string | null) =>
-    apiFetch<UserProfile>('/profile', {
+  update: (update: ProfileUpdate) => {
+    const body: Record<string, unknown> = {}
+    if ('portfolioSlug' in update) body.portfolio_slug = update.portfolioSlug
+    if ('preferredCurrency' in update) body.preferred_currency = update.preferredCurrency
+    return apiFetch<UserProfile>('/profile', {
       method: 'PATCH',
-      body: JSON.stringify({ portfolio_slug: portfolioSlug }),
-    }),
+      body: JSON.stringify(body),
+    })
+  },
 }
 
 // ============================================================================

--- a/app/frontend/lib/currency.ts
+++ b/app/frontend/lib/currency.ts
@@ -53,3 +53,19 @@ export function formatCurrency(
   }
   return formatter.format(value)
 }
+
+export type CurrencyOption = { value: string; label: string }
+
+export const CURRENCY_OPTIONS: CurrencyOption[] = [
+  { value: 'USD', label: 'USD — US Dollar' },
+  { value: 'EUR', label: 'EUR — Euro' },
+  { value: 'GBP', label: 'GBP — Pound Sterling' },
+  { value: 'JPY', label: 'JPY — Japanese Yen' },
+  { value: 'CHF', label: 'CHF — Swiss Franc' },
+  { value: 'CAD', label: 'CAD — Canadian Dollar' },
+  { value: 'AUD', label: 'AUD — Australian Dollar' },
+]
+
+export function formatFxRate(rate: number, locale: string = 'en-US'): string {
+  return rate.toLocaleString(locale, { minimumFractionDigits: 2, maximumFractionDigits: 4 })
+}

--- a/app/frontend/locales/en.ts
+++ b/app/frontend/locales/en.ts
@@ -265,6 +265,8 @@ const en = {
     slugPlaceholder: 'my-portfolio',
     publicUrl: 'Public URL:',
     failedToUpdate: 'Failed to update',
+    displayCurrency: 'Display Currency',
+    displayCurrencyDescription: 'Choose the currency used to sum multi-currency totals. Per-stock prices stay in their listing currency.',
   },
 
   // Admin Page

--- a/app/frontend/locales/es.ts
+++ b/app/frontend/locales/es.ts
@@ -264,6 +264,8 @@ const es = {
     slugPlaceholder: 'mi-cartera',
     publicUrl: 'URL p\u00fablica:',
     failedToUpdate: 'Error al actualizar',
+    displayCurrency: 'Moneda de visualizaci\u00f3n',
+    displayCurrencyDescription: 'Elige la moneda que se usa para sumar totales multi-divisa. Los precios por acci\u00f3n se mantienen en su moneda de cotizaci\u00f3n.',
   },
 
   // Admin Page

--- a/app/frontend/pages/PortfolioPage.tsx
+++ b/app/frontend/pages/PortfolioPage.tsx
@@ -16,8 +16,8 @@ import { Button } from '@/components/ui/button'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
-import { formatCurrency } from '../lib/currency'
-import type { Stock, StockSearchResult } from '../types'
+import { formatCurrency, formatFxRate } from '../lib/currency'
+import type { CurrencyTotals, DisplayTotal, Stock, StockSearchResult } from '../types'
 
 const METRICS_PREFERENCE_KEY = 'portfolio-show-metrics'
 const SORT_PREFERENCE_KEY = 'portfolio-sort-preference'
@@ -164,17 +164,10 @@ export function PortfolioPage() {
               {t('portfolio.title')}
             </CardTitle>
             {holdingsData && holdings.length > 0 && (
-              <div className="text-right text-sm space-y-2">
-                <div className="text-muted-foreground">{t('portfolio.totalValue')}</div>
-                {Object.entries(holdingsData.totalsByCurrency).map(([code, totals]) => (
-                  <div key={code}>
-                    <div className="font-bold text-foreground">{formatCurrency(totals.value, code)}</div>
-                    <div className={cn('text-xs font-medium', totals.gainLoss >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400')}>
-                      {totals.gainLoss >= 0 ? '+' : ''}{formatCurrency(totals.gainLoss, code)} ({totals.gainLossPercent.toFixed(1)}%)
-                    </div>
-                  </div>
-                ))}
-              </div>
+              <PortfolioTotalsHeader
+                totalsByCurrency={holdingsData.totalsByCurrency}
+                displayTotal={holdingsData.displayTotal}
+              />
             )}
           </div>
         </CardHeader>
@@ -467,6 +460,64 @@ export function PortfolioPage() {
           </CardContent>
         </Card>
       )}
+    </div>
+  )
+}
+
+interface PortfolioTotalsHeaderProps {
+  totalsByCurrency: Record<string, CurrencyTotals>
+  displayTotal: DisplayTotal | null
+}
+
+function PortfolioTotalsHeader({ totalsByCurrency, displayTotal }: PortfolioTotalsHeaderProps) {
+  const { t } = useTranslation()
+  const entries = Object.entries(totalsByCurrency)
+  const hasDisplayTotal = displayTotal !== null
+  const isMultiCurrency = entries.length > 1
+  const showBreakdown = hasDisplayTotal && isMultiCurrency
+
+  return (
+    <div className="text-right text-sm space-y-2">
+      <div className="text-muted-foreground">{t('portfolio.totalValue')}</div>
+      {hasDisplayTotal ? (
+        <DisplayTotalBlock displayTotal={displayTotal} />
+      ) : (
+        entries.map(([code, totals]) => <CurrencyTotalRow key={code} code={code} totals={totals} />)
+      )}
+      {showBreakdown && (
+        <div className="pt-1 border-t border-border/40 text-xs text-muted-foreground space-y-0.5">
+          {entries.map(([code, totals]) => (
+            <div key={code}>
+              {formatCurrency(totals.value, code)}
+              {displayTotal.conversions[code] !== undefined && (
+                <span className="opacity-70"> @ {formatFxRate(displayTotal.conversions[code])}</span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function DisplayTotalBlock({ displayTotal }: { displayTotal: DisplayTotal }) {
+  return (
+    <div>
+      <div className="font-bold text-foreground">{formatCurrency(displayTotal.value, displayTotal.currency)}</div>
+      <div className={cn('text-xs font-medium', displayTotal.gainLoss >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400')}>
+        {displayTotal.gainLoss >= 0 ? '+' : ''}{formatCurrency(displayTotal.gainLoss, displayTotal.currency)} ({displayTotal.gainLossPercent.toFixed(1)}%)
+      </div>
+    </div>
+  )
+}
+
+function CurrencyTotalRow({ code, totals }: { code: string; totals: CurrencyTotals }) {
+  return (
+    <div>
+      <div className="font-bold text-foreground">{formatCurrency(totals.value, code)}</div>
+      <div className={cn('text-xs font-medium', totals.gainLoss >= 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400')}>
+        {totals.gainLoss >= 0 ? '+' : ''}{formatCurrency(totals.gainLoss, code)} ({totals.gainLossPercent.toFixed(1)}%)
+      </div>
     </div>
   )
 }

--- a/app/frontend/pages/SettingsPage.tsx
+++ b/app/frontend/pages/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { Loader2, Check, Activity, ExternalLink } from 'lucide-react'
+import { Loader2, Check, Activity, ExternalLink, Coins } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useProfile, useUpdateProfile } from '../hooks/useProfileQueries'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -7,6 +7,7 @@ import { Input } from '@/components/ui/input'
 import { Button } from '@/components/ui/button'
 import { Label } from '@/components/ui/label'
 import { Alert, AlertDescription } from '@/components/ui/alert'
+import { CURRENCY_OPTIONS } from '@/lib/currency'
 
 export function SettingsPage() {
   const { t } = useTranslation()
@@ -14,8 +15,73 @@ export function SettingsPage() {
   return (
     <div className="container mx-auto px-4 py-8 space-y-8">
       <h1 className="text-2xl font-bold">{t('settings.title')}</h1>
+      <DisplayCurrencySection />
       <PortfolioSharingSection />
     </div>
+  )
+}
+
+function DisplayCurrencySection() {
+  const { t } = useTranslation()
+  const { data: profile, isLoading } = useProfile()
+  const updateProfile = useUpdateProfile()
+  const [saved, setSaved] = useState(false)
+
+  if (isLoading) {
+    return <Card><CardContent className="py-8 flex justify-center"><Loader2 className="animate-spin" /></CardContent></Card>
+  }
+
+  const current = profile?.preferredCurrency ?? 'USD'
+
+  const handleChange = (value: string) => {
+    updateProfile.mutate({ preferredCurrency: value }, {
+      onSuccess: () => {
+        setSaved(true)
+        setTimeout(() => setSaved(false), 2000)
+      },
+    })
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Coins className="size-5 text-amber-600 dark:text-amber-400" />
+          {t('settings.displayCurrency')}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          {t('settings.displayCurrencyDescription')}
+        </p>
+        <div className="space-y-2">
+          <Label htmlFor="preferred-currency">{t('settings.displayCurrency')}</Label>
+          <select
+            id="preferred-currency"
+            value={current}
+            onChange={(e) => handleChange(e.target.value)}
+            disabled={updateProfile.isPending}
+            className="flex h-9 w-full max-w-xs rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring disabled:opacity-50"
+          >
+            {CURRENCY_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>{opt.label}</option>
+            ))}
+          </select>
+        </div>
+        {updateProfile.isError && (
+          <Alert variant="destructive">
+            <AlertDescription>
+              {updateProfile.error instanceof Error ? updateProfile.error.message : t('settings.failedToUpdate')}
+            </AlertDescription>
+          </Alert>
+        )}
+        {saved && (
+          <p className="text-sm text-green-600 dark:text-green-400 flex items-center gap-1">
+            <Check className="h-4 w-4" /> {t('common.saved')}
+          </p>
+        )}
+      </CardContent>
+    </Card>
   )
 }
 
@@ -34,7 +100,7 @@ function PortfolioSharingSection() {
 
   const handleSave = () => {
     const value = slug.trim() || null
-    updateProfile.mutate(value, {
+    updateProfile.mutate({ portfolioSlug: value }, {
       onSuccess: () => {
         setSaved(true)
         setTimeout(() => setSaved(false), 2000)
@@ -44,7 +110,7 @@ function PortfolioSharingSection() {
 
   const handleClear = () => {
     setSlug('')
-    updateProfile.mutate(null, {
+    updateProfile.mutate({ portfolioSlug: null }, {
       onSuccess: () => {
         setSaved(true)
         setTimeout(() => setSaved(false), 2000)

--- a/app/frontend/types/index.ts
+++ b/app/frontend/types/index.ts
@@ -130,15 +130,31 @@ export interface CurrencyTotals {
   gainLossPercent: number
 }
 
+/**
+ * Single converted total in the user's preferred currency. Backend omits this
+ * (sends null) when any required FX rate is missing — frontend then falls back
+ * to per-currency rows.
+ */
+export interface DisplayTotal {
+  currency: string
+  value: number
+  cost: number
+  gainLoss: number
+  gainLossPercent: number
+  conversions: Record<string, number>
+}
+
 export interface HoldingsResponse {
   holdings: Holding[]
   totalsByCurrency: Record<string, CurrencyTotals>
+  displayTotal: DisplayTotal | null
 }
 
 export interface UserProfile {
   id: number
   emailAddress: string
   portfolioSlug: string | null
+  preferredCurrency: string
 }
 
 /**
@@ -200,11 +216,22 @@ export interface BuyPlanItem {
  * `totalsByCurrency` is keyed by ISO 4217 code; the cart can mix currencies,
  * so there's no single grand total — the UI renders one row per currency.
  */
+/**
+ * Cart display total in the user's preferred currency. Single field (no cost/gainLoss)
+ * because a buy plan only tracks intended spend.
+ */
+export interface CartDisplayTotal {
+  currency: string
+  total: number
+  conversions: Record<string, number>
+}
+
 export interface BuyPlanResponse {
   id: number | null
   items: BuyPlanItem[]
   totalItems: number
   totalsByCurrency: Record<string, number>
+  displayTotal: CartDisplayTotal | null
 }
 
 /**

--- a/app/jobs/refresh_fx_rates_job.rb
+++ b/app/jobs/refresh_fx_rates_job.rb
@@ -1,0 +1,12 @@
+class RefreshFxRatesJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    pairs = FxRateService.pairs_needed
+    results = FxRateService.refresh_all(pairs)
+    refreshed = results.count { |_, rate| rate }
+    failed = results.count - refreshed
+
+    Rails.logger.info "RefreshFxRatesJob: Refreshed #{refreshed} pairs, #{failed} failures"
+  end
+end

--- a/app/jobs/refresh_stocks_job.rb
+++ b/app/jobs/refresh_stocks_job.rb
@@ -18,12 +18,7 @@ class RefreshStocksJob < ApplicationJob
 
   def publish_portfolio_updates
     User.where.not(portfolio_slug: nil).includes(holdings: :stock).find_each do |user|
-      NatsPublisher.publish("portfolio.updated", {
-        slug: user.portfolio_slug,
-        holdings: user.holdings.map { |h|
-          { symbol: h.stock.symbol, quantity: h.quantity.to_f, avg_price: h.average_price.to_f, price: (h.stock.price || 0).to_f }
-        }
-      })
+      NatsPublisher.publish("portfolio.updated", PortfolioPayloadBuilder.call(user))
     end
   end
 end

--- a/app/models/fx_rate.rb
+++ b/app/models/fx_rate.rb
@@ -1,0 +1,15 @@
+class FxRate < ApplicationRecord
+  STALE_AFTER = 24.hours
+
+  validates :base, :quote, presence: true
+  validates :base, uniqueness: { scope: :quote }
+  validates :rate, presence: true, numericality: { greater_than: 0 }
+
+  scope :fresh, -> { where("fetched_at > ?", STALE_AFTER.ago) }
+
+  def self.upsert_rate(base, quote, rate)
+    record = find_or_initialize_by(base: base, quote: quote)
+    record.update!(rate: rate, fetched_at: Time.current)
+    record
+  end
+end

--- a/app/models/holding.rb
+++ b/app/models/holding.rb
@@ -20,11 +20,6 @@ class Holding < ApplicationRecord
   def publish_portfolio_updated
     return unless user.portfolio_slug.present?
 
-    NatsPublisher.publish("portfolio.updated", {
-      slug: user.portfolio_slug,
-      holdings: user.holdings.includes(:stock).map { |h|
-        { symbol: h.stock.symbol, quantity: h.quantity.to_f, avg_price: h.average_price.to_f, price: (h.stock.price || 0).to_f }
-      }
-    })
+    NatsPublisher.publish("portfolio.updated", PortfolioPayloadBuilder.call(user))
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,6 +14,7 @@ class User < ApplicationRecord
   validates :portfolio_slug, uniqueness: true, allow_nil: true,
     format: { with: /\A[a-z0-9][a-z0-9-]{1,38}[a-z0-9]\z/, message: "must be 3-40 lowercase alphanumeric characters or hyphens" },
     if: -> { portfolio_slug.present? }
+  validates :preferred_currency, presence: true, inclusion: { in: Stock::CURRENCY_SYMBOLS.keys }
 
   after_commit :publish_portfolio_slug_change, if: :saved_change_to_portfolio_slug?
 
@@ -33,12 +34,7 @@ class User < ApplicationRecord
 
   def publish_portfolio_slug_change
     if portfolio_slug.present?
-      NatsPublisher.publish("portfolio.opted_in", {
-        slug: portfolio_slug,
-        holdings: holdings.includes(:stock).map { |h|
-          { symbol: h.stock.symbol, quantity: h.quantity.to_f, avg_price: h.average_price.to_f, price: (h.stock.price || 0).to_f }
-        }
-      })
+      NatsPublisher.publish("portfolio.opted_in", PortfolioPayloadBuilder.call(self))
     else
       previous_slug = saved_change_to_portfolio_slug.first
       NatsPublisher.publish("portfolio.opted_out", { slug: previous_slug }) if previous_slug.present?

--- a/app/services/ai_insights_service.rb
+++ b/app/services/ai_insights_service.rb
@@ -1,15 +1,15 @@
 class AiInsightsService
   class << self
-    def radar_insights(stocks_data, locale: nil)
-      provider.radar_insights(stocks_data, locale: locale)
+    def radar_insights(stocks_data, locale: nil, preferred_currency: nil)
+      provider.radar_insights(stocks_data, locale: locale, preferred_currency: preferred_currency)
     end
 
-    def portfolio_insights(stocks_data, locale: nil)
-      provider.portfolio_insights(stocks_data, locale: locale)
+    def portfolio_insights(stocks_data, locale: nil, preferred_currency: nil)
+      provider.portfolio_insights(stocks_data, locale: locale, preferred_currency: preferred_currency)
     end
 
-    def stock_summary(stock_data, locale: nil)
-      provider.stock_summary(stock_data, locale: locale)
+    def stock_summary(stock_data, locale: nil, preferred_currency: nil)
+      provider.stock_summary(stock_data, locale: locale, preferred_currency: preferred_currency)
     end
 
     private

--- a/app/services/ai_providers/base_provider.rb
+++ b/app/services/ai_providers/base_provider.rb
@@ -7,7 +7,7 @@ module AiProviders
     # @param stocks_data [Array<Hash>] array of stock data hashes
     # @param locale [String, nil] language locale (e.g., "en", "es")
     # @return [Hash] structured insights
-    def radar_insights(stocks_data, locale: nil)
+    def radar_insights(stocks_data, locale: nil, preferred_currency: nil)
       raise NotImplementedError, "Subclasses must implement radar_insights"
     end
 
@@ -16,7 +16,7 @@ module AiProviders
     # @param stocks_data [Array<Hash>] array of stock data hashes
     # @param locale [String, nil] language locale (e.g., "en", "es")
     # @return [Hash] structured insights
-    def portfolio_insights(stocks_data, locale: nil)
+    def portfolio_insights(stocks_data, locale: nil, preferred_currency: nil)
       raise NotImplementedError, "Subclasses must implement portfolio_insights"
     end
 
@@ -25,7 +25,7 @@ module AiProviders
     # @param stock_data [Hash] stock data hash
     # @param locale [String, nil] language locale (e.g., "en", "es")
     # @return [Hash] structured summary with verdict
-    def stock_summary(stock_data, locale: nil)
+    def stock_summary(stock_data, locale: nil, preferred_currency: nil)
       raise NotImplementedError, "Subclasses must implement stock_summary"
     end
 

--- a/app/services/ai_providers/gemini_provider.rb
+++ b/app/services/ai_providers/gemini_provider.rb
@@ -2,42 +2,45 @@ module AiProviders
   class GeminiProvider < BaseProvider
     GEMINI_API_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent".freeze
 
-    def radar_insights(stocks_data, locale: nil)
+    def radar_insights(stocks_data, locale: nil, preferred_currency: nil)
       return empty_radar_insights if stocks_data.blank?
 
       fingerprint = Digest::MD5.hexdigest(stocks_data.to_json)
       lang = normalized_locale(locale)
-      cache_key = "ai/radar/#{fingerprint}/#{lang}"
+      ccy = preferred_currency || "USD"
+      cache_key = "ai/radar/#{fingerprint}/#{lang}/#{ccy}"
 
       cache_fetch(cache_key) do
-        prompt = build_radar_prompt(stocks_data, lang)
+        prompt = build_radar_prompt(stocks_data, lang, ccy)
         response = call_gemini(prompt, radar_response_schema)
         parse_response(response)
       end
     end
 
-    def portfolio_insights(stocks_data, locale: nil)
+    def portfolio_insights(stocks_data, locale: nil, preferred_currency: nil)
       return empty_portfolio_insights if stocks_data.blank?
 
       fingerprint = Digest::MD5.hexdigest(stocks_data.to_json)
       lang = normalized_locale(locale)
-      cache_key = "ai/portfolio/#{fingerprint}/#{lang}"
+      ccy = preferred_currency || "USD"
+      cache_key = "ai/portfolio/#{fingerprint}/#{lang}/#{ccy}"
 
       cache_fetch(cache_key) do
-        prompt = build_portfolio_prompt(stocks_data, lang)
+        prompt = build_portfolio_prompt(stocks_data, lang, ccy)
         response = call_gemini(prompt, radar_response_schema)
         parse_response(response)
       end
     end
 
-    def stock_summary(stock_data, locale: nil)
+    def stock_summary(stock_data, locale: nil, preferred_currency: nil)
       return empty_stock_summary if stock_data.blank?
 
       lang = normalized_locale(locale)
-      cache_key = "ai/stock/#{stock_data[:id]}/#{stock_data[:updated_at]}/#{lang}"
+      ccy = preferred_currency || "USD"
+      cache_key = "ai/stock/#{stock_data[:id]}/#{stock_data[:updated_at]}/#{lang}/#{ccy}"
 
       cache_fetch(cache_key) do
-        prompt = build_stock_prompt(stock_data, lang)
+        prompt = build_stock_prompt(stock_data, lang, ccy)
         response = call_gemini(prompt, stock_response_schema)
         parse_response(response)
       end
@@ -104,13 +107,14 @@ module AiProviders
       parsed.deep_symbolize_keys
     end
 
-    def build_radar_prompt(stocks_data, lang = "en")
+    def build_radar_prompt(stocks_data, lang = "en", preferred_currency = "USD")
       {
         system: <<~SYSTEM,
           You are a dividend investment analyst assistant. Analyze the user's stock watchlist and provide actionable insights.
           Focus on dividend investing strategy: yield quality, payout sustainability, portfolio diversification by payment months, and value opportunities.
           Be concise and specific. Reference stocks by their symbol.
           Prices are denominated in each stock's quoted currency, see the `currency` field on every row; do not assume a single currency across the portfolio.
+          The user's display currency is #{preferred_currency}. If you summarise any portfolio-wide value, use #{preferred_currency} and note that it's converted from each stock's native currency.
           IMPORTANT: The "targetPrice" field is NOT an analyst target — it is the price at which the user personally wants to act (buy or sell). Treat it as the user's desired action price.#{language_instruction(lang)}
         SYSTEM
         user: <<~USER
@@ -128,13 +132,14 @@ module AiProviders
       }
     end
 
-    def build_portfolio_prompt(stocks_data, lang = "en")
+    def build_portfolio_prompt(stocks_data, lang = "en", preferred_currency = "USD")
       {
         system: <<~SYSTEM,
           You are a dividend investment analyst assistant. Analyze the user's actual portfolio holdings and provide actionable insights.
           Focus on dividend investing strategy: yield quality, payout sustainability, portfolio diversification by payment months, and value opportunities.
           Be concise and specific. Reference stocks by their symbol.
           Prices are denominated in each stock's quoted currency, see the `currency` field on every row; do not assume a single currency across the portfolio.
+          The user's display currency is #{preferred_currency}. If you summarise any portfolio-wide value, use #{preferred_currency} and note that it's converted from each stock's native currency.
           IMPORTANT: The "targetPrice" field is NOT an analyst target — it is the price at which the user personally wants to act (buy or sell). Treat it as the user's desired action price.#{language_instruction(lang)}
         SYSTEM
         user: <<~USER
@@ -152,12 +157,13 @@ module AiProviders
       }
     end
 
-    def build_stock_prompt(stock_data, lang = "en")
+    def build_stock_prompt(stock_data, lang = "en", preferred_currency = "USD")
       {
         system: <<~SYSTEM,
           You are a dividend investment analyst assistant. Provide a concise assessment of an individual stock for dividend investing.
           Consider yield, payout ratio, PE ratio, price vs target, 52-week position, dividend score, and MA200 trend.
           Be specific and actionable. Prices are denominated in this stock's quoted currency, see the `currency` field.
+          The user's display currency is #{preferred_currency}; if you reference any computed value, use #{preferred_currency}.
           IMPORTANT: The "targetPrice" field is NOT an analyst target — it is the price at which the user personally wants to act (buy or sell). Treat it as the user's desired action price.#{language_instruction(lang)}
         SYSTEM
         user: <<~USER

--- a/app/services/fx_rate_service.rb
+++ b/app/services/fx_rate_service.rb
@@ -1,0 +1,80 @@
+class FxRateService
+  STALE_AFTER = 24.hours
+  CACHE_TTL = 1.hour
+
+  class << self
+    def convert(amount, from:, to:)
+      return amount if from == to
+
+      r = rate(from: from, to: to)
+      r && amount * r
+    end
+
+    def rate(from:, to:)
+      return 1.0 if from == to
+
+      cached_rate(from, to) || db_rate(from, to) || inverse_rate(from, to) || provider_rate(from, to)
+    end
+
+    def refresh_all(pairs)
+      pairs.each_with_object({}) do |(from, to), results|
+        results["#{from}#{to}"] = provider_rate(from, to)
+      end
+    end
+
+    # Cartesian product of (currencies held by any user × users' preferred currencies),
+    # minus identity pairs. Used by the nightly job to know what to refresh.
+    def pairs_needed
+      holding_currencies = Stock.joins(:holdings).distinct.pluck(:currency)
+      preferred = User.distinct.pluck(:preferred_currency)
+      codes = (holding_currencies + preferred).compact.uniq
+
+      codes.product(codes).reject { |from, to| from == to }
+    end
+
+    private
+
+    def cached_rate(from, to)
+      Rails.cache.read(cache_key(from, to))
+    end
+
+    def db_rate(from, to)
+      raw = db_raw_rate(from, to)
+      cache_and_return(from, to, raw) if raw
+    end
+
+    # Halves traffic for the common any↔USD case: if USDEUR is fresh, EURUSD is just 1/x.
+    def inverse_rate(from, to)
+      inverse = cached_rate(to, from) || db_raw_rate(to, from)
+      return nil unless inverse&.positive?
+
+      cache_and_return(from, to, 1.0 / inverse)
+    end
+
+    def provider_rate(from, to)
+      rate = provider.get_fx_rate(from, to)
+      return nil unless rate&.positive?
+
+      FxRate.upsert_rate(from, to, rate)
+      cache_and_return(from, to, rate.to_f)
+    end
+
+    def db_raw_rate(from, to)
+      FxRate.fresh.find_by(base: from, quote: to)&.rate&.to_f
+    end
+
+    def cache_and_return(from, to, rate)
+      Rails.cache.write(cache_key(from, to), rate, expires_in: CACHE_TTL)
+      rate
+    end
+
+    def cache_key(from, to)
+      "fx/#{from}#{to}"
+    end
+
+    def provider
+      Rails.application.config.respond_to?(:fx_rate_provider) && Rails.application.config.fx_rate_provider ||
+        YahooFinanceClient::Stock
+    end
+  end
+end

--- a/app/services/portfolio_payload_builder.rb
+++ b/app/services/portfolio_payload_builder.rb
@@ -1,0 +1,19 @@
+module PortfolioPayloadBuilder
+  module_function
+
+  def call(user)
+    {
+      slug: user.portfolio_slug,
+      holdings: user.holdings.includes(:stock).map { |h| serialize_holding(h) }
+    }
+  end
+
+  def serialize_holding(holding)
+    {
+      symbol: holding.stock.symbol,
+      quantity: holding.quantity.to_f,
+      avg_price: holding.average_price.to_f,
+      price: (holding.stock.price || 0).to_f
+    }
+  end
+end

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -3,3 +3,7 @@ production:
     class: RefreshStocksJob
     queue: default
     schedule: "<%= ENV.fetch('STOCK_REFRESH_SCHEDULE', 'every 24 hours') %>"
+  refresh_fx_rates:
+    class: RefreshFxRatesJob
+    queue: default
+    schedule: "<%= ENV.fetch('FX_REFRESH_SCHEDULE', 'every 24 hours') %>"

--- a/db/migrate/20260516120000_add_preferred_currency_to_users.rb
+++ b/db/migrate/20260516120000_add_preferred_currency_to_users.rb
@@ -1,0 +1,5 @@
+class AddPreferredCurrencyToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :preferred_currency, :string, default: "USD", null: false
+  end
+end

--- a/db/migrate/20260516120001_create_fx_rates.rb
+++ b/db/migrate/20260516120001_create_fx_rates.rb
@@ -1,0 +1,13 @@
+class CreateFxRates < ActiveRecord::Migration[8.0]
+  def change
+    create_table :fx_rates do |t|
+      t.string :base, null: false
+      t.string :quote, null: false
+      t.decimal :rate, precision: 18, scale: 8, null: false
+      t.datetime :fetched_at, null: false
+
+      t.timestamps
+    end
+    add_index :fx_rates, [ :base, :quote ], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_15_235223) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_16_120001) do
   create_table "buy_plan_items", force: :cascade do |t|
     t.integer "buy_plan_id", null: false
     t.integer "stock_id", null: false
@@ -38,6 +38,16 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_15_235223) do
     t.datetime "updated_at", null: false
     t.index ["stock_id"], name: "index_dividends_on_stock_id"
     t.index ["user_id"], name: "index_dividends_on_user_id"
+  end
+
+  create_table "fx_rates", force: :cascade do |t|
+    t.string "base", null: false
+    t.string "quote", null: false
+    t.decimal "rate", precision: 18, scale: 8, null: false
+    t.datetime "fetched_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["base", "quote"], name: "index_fx_rates_on_base_and_quote", unique: true
   end
 
   create_table "holdings", force: :cascade do |t|
@@ -121,6 +131,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_15_235223) do
     t.string "name"
     t.boolean "admin", default: false, null: false
     t.string "portfolio_slug"
+    t.string "preferred_currency", default: "USD", null: false
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
     t.index ["portfolio_slug"], name: "index_users_on_portfolio_slug", unique: true
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true

--- a/spec/factories/fx_rates.rb
+++ b/spec/factories/fx_rates.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :fx_rate do
+    base { "EUR" }
+    quote { "USD" }
+    rate { 1.10 }
+    fetched_at { Time.current }
+  end
+end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -7,5 +7,9 @@ FactoryBot.define do
     trait :admin do
       admin { true }
     end
+
+    trait :eur_user do
+      preferred_currency { "EUR" }
+    end
   end
 end

--- a/spec/jobs/refresh_fx_rates_job_spec.rb
+++ b/spec/jobs/refresh_fx_rates_job_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+
+RSpec.describe RefreshFxRatesJob, type: :job do
+  describe '#perform' do
+    it 'calls FxRateService.refresh_all with the pairs it needs' do
+      pairs = [ [ "EUR", "USD" ], [ "USD", "EUR" ] ]
+      expect(FxRateService).to receive(:pairs_needed).and_return(pairs)
+      expect(FxRateService).to receive(:refresh_all).with(pairs).and_return("EURUSD" => 1.10, "USDEUR" => 0.91)
+
+      described_class.new.perform
+    end
+
+    it 'logs the refresh result' do
+      allow(FxRateService).to receive_messages(pairs_needed: [], refresh_all: {})
+      expect(Rails.logger).to receive(:info).with(/RefreshFxRatesJob: Refreshed/)
+
+      described_class.new.perform
+    end
+  end
+end

--- a/spec/models/fx_rate_spec.rb
+++ b/spec/models/fx_rate_spec.rb
@@ -1,0 +1,45 @@
+require 'rails_helper'
+
+RSpec.describe FxRate, type: :model do
+  describe 'validations' do
+    subject { build(:fx_rate) }
+
+    it { is_expected.to validate_presence_of(:base) }
+    it { is_expected.to validate_presence_of(:quote) }
+    it { is_expected.to validate_presence_of(:rate) }
+    it { is_expected.to validate_numericality_of(:rate).is_greater_than(0) }
+
+    it 'enforces uniqueness on [base, quote]' do
+      create(:fx_rate, base: "EUR", quote: "USD")
+      duplicate = build(:fx_rate, base: "EUR", quote: "USD")
+      expect(duplicate).not_to be_valid
+    end
+
+    it 'allows the same base with different quotes' do
+      create(:fx_rate, base: "EUR", quote: "USD")
+      expect(build(:fx_rate, base: "EUR", quote: "GBP")).to be_valid
+    end
+  end
+
+  describe '.fresh' do
+    it 'includes rows fetched within STALE_AFTER' do
+      fresh = create(:fx_rate, fetched_at: 1.hour.ago)
+      _stale = create(:fx_rate, base: "GBP", fetched_at: 2.days.ago)
+      expect(described_class.fresh).to contain_exactly(fresh)
+    end
+  end
+
+  describe '.upsert_rate' do
+    it 'inserts a new row when no pair exists' do
+      expect { described_class.upsert_rate("EUR", "USD", 1.10) }.to change(described_class, :count).by(1)
+    end
+
+    it 'updates the rate and fetched_at when the pair already exists' do
+      existing = create(:fx_rate, base: "EUR", quote: "USD", rate: 1.05, fetched_at: 1.day.ago)
+      described_class.upsert_rate("EUR", "USD", 1.15)
+      existing.reload
+      expect(existing.rate.to_f).to eq(1.15)
+      expect(existing.fetched_at).to be > 1.minute.ago
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,6 +16,22 @@ RSpec.describe User, type: :model do
     it { should validate_presence_of(:password).on(:create) }
     it { should validate_length_of(:password).is_at_least(6) }
     it { should validate_uniqueness_of(:portfolio_slug) }
+    it { should validate_presence_of(:preferred_currency) }
+    it { should validate_inclusion_of(:preferred_currency).in_array(Stock::CURRENCY_SYMBOLS.keys) }
+  end
+
+  describe 'preferred_currency' do
+    it 'defaults to USD' do
+      expect(create(:user).preferred_currency).to eq("USD")
+    end
+
+    it 'accepts a supported currency' do
+      expect(build(:user, preferred_currency: "EUR")).to be_valid
+    end
+
+    it 'rejects an unsupported currency' do
+      expect(build(:user, preferred_currency: "XYZ")).not_to be_valid
+    end
   end
 
   describe 'portfolio_slug validation' do

--- a/spec/requests/api/v1/buy_plans_spec.rb
+++ b/spec/requests/api/v1/buy_plans_spec.rb
@@ -59,6 +59,31 @@ RSpec.describe "Api::V1::BuyPlans", type: :request do
           expect(apple_item["formattedPrice"]).to eq("$150.00")
           expect(apple_item["formattedSubtotal"]).to eq("$1,500.00")
         end
+
+        it "exposes a displayTotal in the user's preferred currency" do
+          eur_stock = create(:stock, symbol: "IBE.MC", price: 14.0, currency: "EUR")
+          create(:buy_plan_item, buy_plan: buy_plan, stock: eur_stock, quantity: 20)
+          allow(FxRateService).to receive(:rate).with(from: "EUR", to: "USD").and_return(1.1)
+
+          get "/api/v1/buy_plan"
+
+          json = JSON.parse(response.body)
+          display = json["data"]["displayTotal"]
+          expect(display["currency"]).to eq("USD")
+          expect(display["total"]).to be_within(0.01).of(3500.0 + 280.0 * 1.1)
+          expect(display["conversions"]).to eq("EUR" => 1.1)
+        end
+
+        it "returns nil displayTotal when an FX rate is unavailable" do
+          eur_stock = create(:stock, symbol: "IBE.MC", price: 14.0, currency: "EUR")
+          create(:buy_plan_item, buy_plan: buy_plan, stock: eur_stock, quantity: 20)
+          allow(FxRateService).to receive(:rate).and_return(nil)
+
+          get "/api/v1/buy_plan"
+
+          json = JSON.parse(response.body)
+          expect(json["data"]["displayTotal"]).to be_nil
+        end
       end
     end
   end

--- a/spec/requests/api/v1/holdings_spec.rb
+++ b/spec/requests/api/v1/holdings_spec.rb
@@ -63,6 +63,47 @@ RSpec.describe "Api::V1::Holdings", type: :request do
         expect(totals["EUR"]["cost"]).to eq(240.0)
         expect(totals["EUR"]["gainLoss"]).to eq(40.0)
       end
+
+      describe "displayTotal" do
+        let(:eur_stock) { create(:stock, symbol: "IBE.MC", name: "Iberdrola", price: 14.0, currency: "EUR") }
+
+        before do
+          create(:holding, user: user, stock: stock, quantity: 10, average_price: 100.00)
+          create(:holding, user: user, stock: eur_stock, quantity: 20, average_price: 12.0)
+        end
+
+        it "converts mixed-currency totals into the user's preferred currency" do
+          allow(FxRateService).to receive(:rate).with(from: "EUR", to: "USD").and_return(1.1)
+
+          get "/api/v1/holdings"
+
+          json = JSON.parse(response.body)
+          display = json["data"]["displayTotal"]
+          expect(display["currency"]).to eq("USD")
+          expect(display["value"]).to be_within(0.01).of(1500.0 + 280.0 * 1.1)
+          expect(display["conversions"]).to eq("EUR" => 1.1)
+        end
+
+        it "honors a non-USD preferred currency" do
+          user.update!(preferred_currency: "EUR")
+          allow(FxRateService).to receive(:rate).with(from: "USD", to: "EUR").and_return(0.9)
+
+          get "/api/v1/holdings"
+
+          json = JSON.parse(response.body)
+          expect(json["data"]["displayTotal"]["currency"]).to eq("EUR")
+          expect(json["data"]["displayTotal"]["conversions"]).to eq("USD" => 0.9)
+        end
+
+        it "returns nil when any required rate is unavailable" do
+          allow(FxRateService).to receive(:rate).and_return(nil)
+
+          get "/api/v1/holdings"
+
+          json = JSON.parse(response.body)
+          expect(json["data"]["displayTotal"]).to be_nil
+        end
+      end
     end
   end
 

--- a/spec/requests/api/v1/profiles_spec.rb
+++ b/spec/requests/api/v1/profiles_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe "Api::V1::Profiles", type: :request do
         json = JSON.parse(response.body)
         expect(json["data"]["emailAddress"]).to eq(user.email_address)
         expect(json["data"]["portfolioSlug"]).to be_nil
+        expect(json["data"]["preferredCurrency"]).to eq("USD")
       end
     end
   end
@@ -47,6 +48,21 @@ RSpec.describe "Api::V1::Profiles", type: :request do
 
       it "rejects invalid slug format" do
         patch "/api/v1/profile", params: { portfolio_slug: "AB" }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "updates the preferred currency" do
+        patch "/api/v1/profile", params: { preferred_currency: "EUR" }
+
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)
+        expect(json["data"]["preferredCurrency"]).to eq("EUR")
+        expect(user.reload.preferred_currency).to eq("EUR")
+      end
+
+      it "rejects an unsupported currency" do
+        patch "/api/v1/profile", params: { preferred_currency: "XYZ" }
 
         expect(response).to have_http_status(:unprocessable_entity)
       end

--- a/spec/requests/api/v1/radar_insights_spec.rb
+++ b/spec/requests/api/v1/radar_insights_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "Api::V1::Radars#insights", type: :request do
           get "/api/v1/radar/insights"
 
           expect(response).to have_http_status(:ok)
-          expect(AiInsightsService).to have_received(:radar_insights).with([], locale: nil)
+          expect(AiInsightsService).to have_received(:radar_insights).with([], locale: nil, preferred_currency: "USD")
         end
       end
 

--- a/spec/services/ai_insights_service_spec.rb
+++ b/spec/services/ai_insights_service_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe AiInsightsService, type: :service do
       result = described_class.radar_insights(stocks_data)
 
       expect(result).to eq(radar_insights_result)
-      expect(provider).to have_received(:radar_insights).with(stocks_data, locale: nil)
+      expect(provider).to have_received(:radar_insights).with(stocks_data, locale: nil, preferred_currency: nil)
     end
   end
 
@@ -52,7 +52,7 @@ RSpec.describe AiInsightsService, type: :service do
       result = described_class.stock_summary(stock_data)
 
       expect(result).to eq(stock_summary_result)
-      expect(provider).to have_received(:stock_summary).with(stock_data, locale: nil)
+      expect(provider).to have_received(:stock_summary).with(stock_data, locale: nil, preferred_currency: nil)
     end
   end
 end

--- a/spec/services/fx_rate_service_spec.rb
+++ b/spec/services/fx_rate_service_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+RSpec.describe FxRateService do
+  before do
+    Rails.cache.clear
+    allow(YahooFinanceClient::Stock).to receive(:get_fx_rate).and_return(nil)
+  end
+
+  describe '.rate' do
+    it 'returns 1.0 for identity pairs without hitting any layer' do
+      expect(YahooFinanceClient::Stock).not_to receive(:get_fx_rate)
+      expect(described_class.rate(from: "USD", to: "USD")).to eq(1.0)
+    end
+
+    it 'reads from Rails.cache when warm' do
+      Rails.cache.write("fx/EURUSD", 1.10)
+      expect(YahooFinanceClient::Stock).not_to receive(:get_fx_rate)
+      expect(described_class.rate(from: "EUR", to: "USD")).to eq(1.10)
+    end
+
+    it 'falls back to a fresh DB row when cache is empty' do
+      create(:fx_rate, base: "EUR", quote: "USD", rate: 1.10, fetched_at: 1.hour.ago)
+      expect(YahooFinanceClient::Stock).not_to receive(:get_fx_rate)
+      expect(described_class.rate(from: "EUR", to: "USD")).to eq(1.10)
+    end
+
+    it 'ignores stale DB rows and refetches from provider' do
+      create(:fx_rate, base: "EUR", quote: "USD", rate: 1.05, fetched_at: 2.days.ago)
+      allow(YahooFinanceClient::Stock).to receive(:get_fx_rate).with("EUR", "USD").and_return(1.20)
+      expect(described_class.rate(from: "EUR", to: "USD")).to eq(1.20)
+    end
+
+    it 'derives the inverse from a fresh forward DB row' do
+      create(:fx_rate, base: "EUR", quote: "USD", rate: 1.25, fetched_at: 1.hour.ago)
+      expect(YahooFinanceClient::Stock).not_to receive(:get_fx_rate)
+      expect(described_class.rate(from: "USD", to: "EUR")).to be_within(0.0001).of(0.8)
+    end
+
+    it 'derives the inverse from a cached forward rate' do
+      Rails.cache.write("fx/EURUSD", 2.0)
+      expect(YahooFinanceClient::Stock).not_to receive(:get_fx_rate)
+      expect(described_class.rate(from: "USD", to: "EUR")).to eq(0.5)
+    end
+
+    it 'fetches from the provider when nothing is cached or stored' do
+      allow(YahooFinanceClient::Stock).to receive(:get_fx_rate).with("GBP", "USD").and_return(1.27)
+      expect(described_class.rate(from: "GBP", to: "USD")).to eq(1.27)
+    end
+
+    it 'persists the provider result to the DB' do
+      allow(YahooFinanceClient::Stock).to receive(:get_fx_rate).with("GBP", "USD").and_return(1.27)
+      expect { described_class.rate(from: "GBP", to: "USD") }.to change(FxRate, :count).by(1)
+    end
+
+    it 'returns nil when the provider returns nil' do
+      allow(YahooFinanceClient::Stock).to receive(:get_fx_rate).and_return(nil)
+      expect(described_class.rate(from: "XXX", to: "USD")).to be_nil
+    end
+  end
+
+  describe '.convert' do
+    it 'returns the amount unchanged for identity pairs' do
+      expect(described_class.convert(100.0, from: "USD", to: "USD")).to eq(100.0)
+    end
+
+    it 'multiplies by the rate' do
+      Rails.cache.write("fx/EURUSD", 1.10)
+      expect(described_class.convert(100.0, from: "EUR", to: "USD")).to be_within(0.0001).of(110.0)
+    end
+
+    it 'returns nil when no rate is available' do
+      expect(described_class.convert(100.0, from: "XXX", to: "USD")).to be_nil
+    end
+  end
+
+  describe '.pairs_needed' do
+    it 'returns the cartesian product of holding currencies × user preferences, minus identity' do
+      eur = create(:stock, symbol: "IBE.MC", currency: "EUR")
+      usd = create(:stock, symbol: "AAPL", currency: "USD")
+      user_usd = create(:user, preferred_currency: "USD")
+      user_eur = create(:user, preferred_currency: "EUR")
+      create(:holding, user: user_usd, stock: eur)
+      create(:holding, user: user_eur, stock: usd)
+
+      expect(described_class.pairs_needed).to contain_exactly([ "EUR", "USD" ], [ "USD", "EUR" ])
+    end
+  end
+
+  describe '.refresh_all' do
+    it 'calls the provider for each pair and returns the result map' do
+      allow(YahooFinanceClient::Stock).to receive(:get_fx_rate).with("EUR", "USD").and_return(1.10)
+      allow(YahooFinanceClient::Stock).to receive(:get_fx_rate).with("GBP", "USD").and_return(1.27)
+
+      results = described_class.refresh_all([ [ "EUR", "USD" ], [ "GBP", "USD" ] ])
+
+      expect(results).to eq("EURUSD" => 1.10, "GBPUSD" => 1.27)
+    end
+  end
+end

--- a/spec/services/portfolio_payload_builder_spec.rb
+++ b/spec/services/portfolio_payload_builder_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe PortfolioPayloadBuilder do
+  describe '.call' do
+    let(:user) { create(:user, portfolio_slug: "alice") }
+    let(:stock) { create(:stock, symbol: "AAPL", price: 175.50) }
+
+    before { create(:holding, user: user, stock: stock, quantity: 10, average_price: 150.0) }
+
+    it 'returns the v1 payload shape: slug + serialized holdings' do
+      expect(described_class.call(user)).to eq(
+        slug: "alice",
+        holdings: [
+          { symbol: "AAPL", quantity: 10.0, avg_price: 150.0, price: 175.50 }
+        ]
+      )
+    end
+
+    it 'coerces missing stock price to 0.0' do
+      stock.update_column(:price, nil)
+      payload = described_class.call(user)
+      expect(payload[:holdings].first[:price]).to eq(0.0)
+    end
+
+    it 'serializes every holding for the user' do
+      goog = create(:stock, symbol: "GOOG", price: 200.0)
+      create(:holding, user: user, stock: goog, quantity: 5, average_price: 180.0)
+
+      symbols = described_class.call(user)[:holdings].map { |h| h[:symbol] }
+      expect(symbols).to contain_exactly("AAPL", "GOOG")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- New `FxRateService` (Yahoo via `yahoo_finance_client` 0.7.0) with a four-tier lookup (identity → 1h `Rails.cache` → fresh `FxRate` row ≤24h → provider) and an inverse-pair shortcut that derives EUR→USD from a cached USD→EUR rate. Nightly `RefreshFxRatesJob` refreshes the cartesian product of holding currencies × users' preferred currencies.
- `users.preferred_currency` (default `USD`, validated against `Stock::CURRENCY_SYMBOLS`) — picked by the user via a new "Display Currency" section on `/settings`.
- `HoldingsController#index` and `BuyPlansController#show` now return an optional `displayTotal` (single converted total in the user's preferred currency + the conversion rates used). Frontend renders the converted total as the primary line on the portfolio header with a per-currency breakdown (`$1,000 + €500 @ 1.10`) underneath. When any FX rate is missing the backend returns `displayTotal: null` and the frontend falls back to the existing per-currency rows.
- `PortfolioPayloadBuilder` extracted as a single chokepoint for the NATS payload (three near-identical inline copies before). Byte-identical to the v1 wire format in this PR — the v2 upgrade ships separately.
- Gemini's system prompt is told the user's display currency so verbal portfolio-wide summaries read in the right unit (the API still pre-converts; the LLM doesn't do arithmetic).

## Out of scope (phase 2 follow-ups)
- **Pulse-side NATS v2 reader** (back-compat). Separate PR.
- **Rails-side v2 emit** (`version: 2`, `base_currency`, `value_in_base`, `value_in_usd`). Separate PR, after pulse is on the v2 reader.
- Cart-side `displayTotal` UI surfacing — the API exposes it, the cart still renders per-currency totals because the cart is edited client-side and the server's pre-converted total goes stale on every add/remove. Will revisit if needed.

## Test plan
- [x] `bundle exec rspec` — 438 examples, 0 failures, 1 pending (the existing flaky sessions spec).
- [x] `bin/rubocop` — clean.
- [x] `npx tsc --noEmit` — clean.
- [ ] Manual: hit `/settings`, switch USD → EUR; add IBE.MC (EUR) + AAPL (USD) holdings; confirm header shows `~€xxx ($yyy + €zzz @ 0.9x)` and per-stock cards stay in their native currency.
- [ ] Manual: `rails runner 'puts FxRateService.rate(from: "EUR", to: "USD").inspect'` returns a float and `FxRate.all` has one row.
- [ ] Manual: unplug the network, refresh `/portfolio`; expect graceful fallback to per-currency rows (no `\$NaN`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)