### PR TITLE
Emit v2 NATS payload with currency + value_in_base/usd

### DIFF
--- a/app/services/portfolio_payload_builder.rb
+++ b/app/services/portfolio_payload_builder.rb
@@ -1,19 +1,42 @@
 module PortfolioPayloadBuilder
   module_function
 
+  # v2 payload — pulse PR #29 reads version, base_currency, and the per-holding
+  # currency / value_in_base / value_in_usd fields. Pulse's v1 fallback clause
+  # still works for the legacy top-level holding fields (symbol/quantity/avg_price/
+  # price), which we keep emitting for one release in case of a pulse rollback.
+  PAYLOAD_VERSION = 2
+
   def call(user)
+    base_currency = user.preferred_currency || "USD"
     {
+      version: PAYLOAD_VERSION,
       slug: user.portfolio_slug,
-      holdings: user.holdings.includes(:stock).map { |h| serialize_holding(h) }
+      base_currency: base_currency,
+      holdings: user.holdings.includes(:stock).map { |h| serialize_holding(h, base_currency) }
     }
   end
 
-  def serialize_holding(holding)
+  def serialize_holding(holding, base_currency)
+    stock = holding.stock
+    price = (stock.price || 0).to_f
+    value_native = price * holding.quantity.to_f
+    value_in_base = FxRateService.convert(value_native, from: stock.currency, to: base_currency)
+    value_in_usd =
+      if base_currency == "USD"
+        value_in_base
+      else
+        FxRateService.convert(value_native, from: stock.currency, to: "USD")
+      end
+
     {
-      symbol: holding.stock.symbol,
+      symbol: stock.symbol,
+      currency: stock.currency,
       quantity: holding.quantity.to_f,
       avg_price: holding.average_price.to_f,
-      price: (holding.stock.price || 0).to_f
+      price: price,
+      value_in_base: value_in_base,
+      value_in_usd: value_in_usd
     }
   end
 end

--- a/spec/services/portfolio_payload_builder_spec.rb
+++ b/spec/services/portfolio_payload_builder_spec.rb
@@ -3,23 +3,42 @@ require 'rails_helper'
 RSpec.describe PortfolioPayloadBuilder do
   describe '.call' do
     let(:user) { create(:user, portfolio_slug: "alice") }
-    let(:stock) { create(:stock, symbol: "AAPL", price: 175.50) }
+    let(:stock) { create(:stock, symbol: "AAPL", currency: "USD", price: 175.50) }
 
-    before { create(:holding, user: user, stock: stock, quantity: 10, average_price: 150.0) }
+    before do
+      create(:holding, user: user, stock: stock, quantity: 10, average_price: 150.0)
+      allow(FxRateService).to receive(:convert) do |amount, **_opts|
+        amount
+      end
+    end
 
-    it 'returns the v1 payload shape: slug + serialized holdings' do
-      expect(described_class.call(user)).to eq(
-        slug: "alice",
-        holdings: [
-          { symbol: "AAPL", quantity: 10.0, avg_price: 150.0, price: 175.50 }
-        ]
-      )
+    it 'emits the v2 envelope (version + base_currency)' do
+      payload = described_class.call(user)
+      expect(payload[:version]).to eq(2)
+      expect(payload[:slug]).to eq("alice")
+      expect(payload[:base_currency]).to eq("USD")
+    end
+
+    it 'keeps the legacy per-holding fields for the pulse v1 fallback' do
+      holding = described_class.call(user)[:holdings].first
+      expect(holding[:symbol]).to eq("AAPL")
+      expect(holding[:quantity]).to eq(10.0)
+      expect(holding[:avg_price]).to eq(150.0)
+      expect(holding[:price]).to eq(175.50)
+    end
+
+    it 'adds the v2 fields: currency, value_in_base, value_in_usd' do
+      holding = described_class.call(user)[:holdings].first
+      expect(holding[:currency]).to eq("USD")
+      expect(holding[:value_in_base]).to eq(1755.0)
+      expect(holding[:value_in_usd]).to eq(1755.0)
     end
 
     it 'coerces missing stock price to 0.0' do
       stock.update_column(:price, nil)
       payload = described_class.call(user)
       expect(payload[:holdings].first[:price]).to eq(0.0)
+      expect(payload[:holdings].first[:value_in_base]).to eq(0.0)
     end
 
     it 'serializes every holding for the user' do
@@ -28,6 +47,44 @@ RSpec.describe PortfolioPayloadBuilder do
 
       symbols = described_class.call(user)[:holdings].map { |h| h[:symbol] }
       expect(symbols).to contain_exactly("AAPL", "GOOG")
+    end
+
+    context 'with a non-USD base currency' do
+      let(:eur_stock) { create(:stock, symbol: "IBE.MC", currency: "EUR", price: 14.50) }
+
+      before do
+        user.update!(preferred_currency: "EUR")
+        create(:holding, user: user, stock: eur_stock, quantity: 20, average_price: 12.0)
+        allow(FxRateService).to receive(:convert).with(1755.0, from: "USD", to: "EUR").and_return(1580.0)
+        allow(FxRateService).to receive(:convert).with(290.0, from: "EUR", to: "EUR").and_return(290.0)
+        allow(FxRateService).to receive(:convert).with(1755.0, from: "USD", to: "USD").and_return(1755.0)
+        allow(FxRateService).to receive(:convert).with(290.0, from: "EUR", to: "USD").and_return(319.0)
+      end
+
+      it 'sets base_currency to the user preference' do
+        expect(described_class.call(user)[:base_currency]).to eq("EUR")
+      end
+
+      it 'converts the USD holding into the EUR base' do
+        aapl = described_class.call(user)[:holdings].find { |h| h[:symbol] == "AAPL" }
+        expect(aapl[:value_in_base]).to eq(1580.0)
+        expect(aapl[:value_in_usd]).to eq(1755.0)
+      end
+
+      it 'leaves the EUR holding untouched in base and converts to USD separately' do
+        ibe = described_class.call(user)[:holdings].find { |h| h[:symbol] == "IBE.MC" }
+        expect(ibe[:value_in_base]).to eq(290.0)
+        expect(ibe[:value_in_usd]).to eq(319.0)
+      end
+    end
+
+    context 'when an FX rate is unavailable' do
+      it 'emits nil for value_in_base so pulse falls back to its v1 math' do
+        allow(FxRateService).to receive(:convert).and_return(nil)
+        holding = described_class.call(user)[:holdings].first
+        expect(holding[:value_in_base]).to be_nil
+        expect(holding[:value_in_usd]).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
> **Stacked on #138** — base branch is \`feat/multi-currency-phase-2\`. GitHub will auto-rebase the target to \`main\` once #138 merges.

## Summary
Switches \`PortfolioPayloadBuilder\` from the v1 shape to v2:
- top-level: \`version: 2\`, \`base_currency\` (user's preferred currency)
- per-holding: \`currency\`, \`value_in_base\` (pre-converted), \`value_in_usd\` (cross-portfolio normalisation key)

Legacy fields (\`symbol\`, \`quantity\`, \`avg_price\`, \`price\`) stay so an older pulse deploy keeps working via its v1 fallback clause. Drop them in a follow-up release once pulse #29 is everywhere.

When \`FxRateService\` returns nil (transient FX failure, no cached row), \`value_in_base\`/\`value_in_usd\` are nil and pulse falls back to its v1 \`quantity * price\` math. Degraded but functional.

## Deploy order
1. Merge & deploy [pulse #29](https://github.com/fleveque/pulse/pull/29) — pulse learns both shapes.
2. Merge & deploy #138 — dividend-portfolio phase 2 (settings UI + displayTotal + the byte-identical v1 builder extraction).
3. Merge & deploy this PR — dividend-portfolio starts emitting v2.
4. Soak; later drop the v1 fields here and the v1 fallback in pulse.

## Test plan
- [x] \`bundle exec rspec\` — 444 examples, 0 failures, 1 pending.
- [x] \`bin/rubocop\` — clean.
- [ ] Manual: after deploying pulse #29 to beta, deploy this here and confirm \`/p/<slug>\` allocations match the rails portfolio view; \`/\` community total still aggregates correctly.
- [ ] Rollback drill: stop emitting v2 for a single user and confirm pulse falls back to v1 math without error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)