### PR TITLE
Emit v2 NATS payload with currency + value_in_base/usd

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,18 @@ AI-enhanced dividend investing platform built with Rails 8 and React. Track your
 
 ```
 Rails publishes on holding changes:
-  {env}.portfolio.updated     {slug, holdings: [{symbol, quantity, avg_price}]}
+  {env}.portfolio.updated     {version: 2, slug, base_currency,
+                               holdings: [{symbol, currency, quantity, avg_price,
+                                           price, value_in_base, value_in_usd}, ...]}
 
 Pulse consumes -> updates GenServer state -> pushes to LiveView via PubSub
 ```
+
+`value_in_base` is each holding's value pre-converted into the user's preferred
+currency (via `FxRateService`); `value_in_usd` is the cross-portfolio
+normalisation key the community dashboard sums on. The legacy `symbol/quantity/
+avg_price/price` fields are kept so an older Pulse deploy can still compute totals
+during the rollover.
 
 ## Features
 
@@ -62,6 +70,7 @@ Pulse consumes -> updates GenServer state -> pushes to LiveView via PubSub
 - **Pulse Integration**: Opt-in to share your portfolio publicly via [Pulse](https://github.com/fleveque/pulse). Set a portfolio slug in settings; holdings sync in real-time via NATS.
 - **Admin Dashboard**: Protected admin area with app stats (users, stocks, radars, portfolios, Pulse adoption), user management, and manual stock refresh.
 - **Mobile Responsive**: Full functionality on any device with hamburger menu navigation.
+- **Multi-Currency Support**: Each stock keeps its listing currency (USD, EUR, GBP, JPY, …); portfolio totals split per currency and convert to your chosen display currency via FX rates fetched from Yahoo. London-pence (`GBp`) and similar minor-unit quotes are normalised at ingest.
 
 ## Admin
 
@@ -85,10 +94,6 @@ bin/kamal app exec "bin/rails admin:grant[your@email.com]"
 - **Dashboard stats**: Users, stocks, radars, buy plans, portfolios, holdings, and Pulse adoption
 - **User management**: View all users with metadata (holdings count, Pulse slug), delete users
 - **Stock refresh**: Manually trigger a stock data refresh job
-
-## Limitations
-
-- Currently the application doesn't allow multiple currencies.
 
 ## Installation
 

--- a/app/services/portfolio_payload_builder.rb
+++ b/app/services/portfolio_payload_builder.rb
@@ -1,19 +1,42 @@
 module PortfolioPayloadBuilder
   module_function
 
+  # v2 payload — pulse PR #29 reads version, base_currency, and the per-holding
+  # currency / value_in_base / value_in_usd fields. Pulse's v1 fallback clause
+  # still works for the legacy top-level holding fields (symbol/quantity/avg_price/
+  # price), which we keep emitting for one release in case of a pulse rollback.
+  PAYLOAD_VERSION = 2
+
   def call(user)
+    base_currency = user.preferred_currency || "USD"
     {
+      version: PAYLOAD_VERSION,
       slug: user.portfolio_slug,
-      holdings: user.holdings.includes(:stock).map { |h| serialize_holding(h) }
+      base_currency: base_currency,
+      holdings: user.holdings.includes(:stock).map { |h| serialize_holding(h, base_currency) }
     }
   end
 
-  def serialize_holding(holding)
+  def serialize_holding(holding, base_currency)
+    stock = holding.stock
+    price = (stock.price || 0).to_f
+    value_native = price * holding.quantity.to_f
+    value_in_base = FxRateService.convert(value_native, from: stock.currency, to: base_currency)
+    value_in_usd =
+      if base_currency == "USD"
+        value_in_base
+      else
+        FxRateService.convert(value_native, from: stock.currency, to: "USD")
+      end
+
     {
-      symbol: holding.stock.symbol,
+      symbol: stock.symbol,
+      currency: stock.currency,
       quantity: holding.quantity.to_f,
       avg_price: holding.average_price.to_f,
-      price: (holding.stock.price || 0).to_f
+      price: price,
+      value_in_base: value_in_base,
+      value_in_usd: value_in_usd
     }
   end
 end

--- a/spec/services/portfolio_payload_builder_spec.rb
+++ b/spec/services/portfolio_payload_builder_spec.rb
@@ -3,23 +3,42 @@ require 'rails_helper'
 RSpec.describe PortfolioPayloadBuilder do
   describe '.call' do
     let(:user) { create(:user, portfolio_slug: "alice") }
-    let(:stock) { create(:stock, symbol: "AAPL", price: 175.50) }
+    let(:stock) { create(:stock, symbol: "AAPL", currency: "USD", price: 175.50) }
 
-    before { create(:holding, user: user, stock: stock, quantity: 10, average_price: 150.0) }
+    before do
+      create(:holding, user: user, stock: stock, quantity: 10, average_price: 150.0)
+      allow(FxRateService).to receive(:convert) do |amount, **_opts|
+        amount
+      end
+    end
 
-    it 'returns the v1 payload shape: slug + serialized holdings' do
-      expect(described_class.call(user)).to eq(
-        slug: "alice",
-        holdings: [
-          { symbol: "AAPL", quantity: 10.0, avg_price: 150.0, price: 175.50 }
-        ]
-      )
+    it 'emits the v2 envelope (version + base_currency)' do
+      payload = described_class.call(user)
+      expect(payload[:version]).to eq(2)
+      expect(payload[:slug]).to eq("alice")
+      expect(payload[:base_currency]).to eq("USD")
+    end
+
+    it 'keeps the legacy per-holding fields for the pulse v1 fallback' do
+      holding = described_class.call(user)[:holdings].first
+      expect(holding[:symbol]).to eq("AAPL")
+      expect(holding[:quantity]).to eq(10.0)
+      expect(holding[:avg_price]).to eq(150.0)
+      expect(holding[:price]).to eq(175.50)
+    end
+
+    it 'adds the v2 fields: currency, value_in_base, value_in_usd' do
+      holding = described_class.call(user)[:holdings].first
+      expect(holding[:currency]).to eq("USD")
+      expect(holding[:value_in_base]).to eq(1755.0)
+      expect(holding[:value_in_usd]).to eq(1755.0)
     end
 
     it 'coerces missing stock price to 0.0' do
       stock.update_column(:price, nil)
       payload = described_class.call(user)
       expect(payload[:holdings].first[:price]).to eq(0.0)
+      expect(payload[:holdings].first[:value_in_base]).to eq(0.0)
     end
 
     it 'serializes every holding for the user' do
@@ -28,6 +47,44 @@ RSpec.describe PortfolioPayloadBuilder do
 
       symbols = described_class.call(user)[:holdings].map { |h| h[:symbol] }
       expect(symbols).to contain_exactly("AAPL", "GOOG")
+    end
+
+    context 'with a non-USD base currency' do
+      let(:eur_stock) { create(:stock, symbol: "IBE.MC", currency: "EUR", price: 14.50) }
+
+      before do
+        user.update!(preferred_currency: "EUR")
+        create(:holding, user: user, stock: eur_stock, quantity: 20, average_price: 12.0)
+        allow(FxRateService).to receive(:convert).with(1755.0, from: "USD", to: "EUR").and_return(1580.0)
+        allow(FxRateService).to receive(:convert).with(290.0, from: "EUR", to: "EUR").and_return(290.0)
+        allow(FxRateService).to receive(:convert).with(1755.0, from: "USD", to: "USD").and_return(1755.0)
+        allow(FxRateService).to receive(:convert).with(290.0, from: "EUR", to: "USD").and_return(319.0)
+      end
+
+      it 'sets base_currency to the user preference' do
+        expect(described_class.call(user)[:base_currency]).to eq("EUR")
+      end
+
+      it 'converts the USD holding into the EUR base' do
+        aapl = described_class.call(user)[:holdings].find { |h| h[:symbol] == "AAPL" }
+        expect(aapl[:value_in_base]).to eq(1580.0)
+        expect(aapl[:value_in_usd]).to eq(1755.0)
+      end
+
+      it 'leaves the EUR holding untouched in base and converts to USD separately' do
+        ibe = described_class.call(user)[:holdings].find { |h| h[:symbol] == "IBE.MC" }
+        expect(ibe[:value_in_base]).to eq(290.0)
+        expect(ibe[:value_in_usd]).to eq(319.0)
+      end
+    end
+
+    context 'when an FX rate is unavailable' do
+      it 'emits nil for value_in_base so pulse falls back to its v1 math' do
+        allow(FxRateService).to receive(:convert).and_return(nil)
+        holding = described_class.call(user)[:holdings].first
+        expect(holding[:value_in_base]).to be_nil
+        expect(holding[:value_in_usd]).to be_nil
+      end
     end
   end
 end


### PR DESCRIPTION
> Continues from closed #139 (auto-closed when phase 2 base branch was deleted on merge). Rebased onto main.

## Summary
Switches \`PortfolioPayloadBuilder\` from the v1 shape to v2:
- top-level: \`version: 2\`, \`base_currency\` (user's preferred currency)
- per-holding: \`currency\`, \`value_in_base\` (pre-converted), \`value_in_usd\` (cross-portfolio normalisation key)

Legacy fields (\`symbol\`, \`quantity\`, \`avg_price\`, \`price\`) stay so an older pulse deploy keeps working via its v1 fallback clause. Drop them in a follow-up release once everyone's on the new pulse.

When \`FxRateService\` returns nil (transient FX failure, no cached row), \`value_in_base\`/\`value_in_usd\` are nil and pulse falls back to its v1 \`quantity * price\` math.

## Deploy order
- [x] pulse #29 merged and deploying (learns both v1 and v2).
- [x] dividend-portfolio #138 merged and deploying (settings UI + displayTotal, still v1 NATS).
- [ ] **This PR** — start emitting v2.
- [ ] Soak, then a follow-up PR drops the v1 legacy fields on both sides.

## Test plan
- [x] \`bundle exec rspec\` — 444 examples, 0 failures, 1 pending.
- [x] \`bin/rubocop\` — clean.
- [ ] Manual after deploy: confirm \`/p/<slug>\` allocations on pulse match the rails portfolio view; \`/\` community total still aggregates correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)