### PR TITLE
Stop dividing dividend/eps by 100 for minor-unit listings

### DIFF
--- a/app/services/financial_data_providers/base_provider.rb
+++ b/app/services/financial_data_providers/base_provider.rb
@@ -20,7 +20,11 @@ module FinancialDataProviders
     MINOR_UNIT_CURRENCIES = {
       "GBp" => [ "GBP", 100 ], "ZAc" => [ "ZAR", 100 ], "ILA" => [ "ILS", 100 ]
     }.freeze
-    PRICE_FIELDS = %i[price eps dividend ma_50 ma_200 fifty_two_week_high fifty_two_week_low].freeze
+    # Yahoo returns the price-family fields (regularMarketPrice and its moving averages /
+    # 52-week range) in the listing's quote unit (GBp for DGE.L, etc.), but `dividendRate`
+    # and `epsTrailingTwelveMonths` already come back in the major unit (GBP). Don't
+    # normalize them or we'd shrink a £0.81 dividend to £0.0081.
+    PRICE_FIELDS = %i[price ma_50 ma_200 fifty_two_week_high fifty_two_week_low].freeze
 
     # Fetches stock data from the provider's API, stores it in the database and caches the result.
     #

--- a/spec/services/financial_data_providers/base_provider_spec.rb
+++ b/spec/services/financial_data_providers/base_provider_spec.rb
@@ -218,8 +218,10 @@ RSpec.describe FinancialDataProviders::BaseProvider, type: :model do
     let(:gbp_provider) do
       Class.new(described_class) do
         def fetch_and_normalize_stock(_symbol)
+          # Yahoo emits the price-family fields in pence (GBp) for DGE.L but the
+          # dividend and EPS come back already in pounds — mirror that here.
           { symbol: 'DGE.L', price: 1529.50, currency: 'GBp',
-            eps: 80.0, dividend: 60.0, ma_50: 1500.0, ma_200: 1450.0,
+            eps: 0.80, dividend: 0.63, ma_50: 1500.0, ma_200: 1450.0,
             fifty_two_week_high: 1800.0, fifty_two_week_low: 1200.0,
             dividend_yield: 3.92, payout_ratio: 75.0, pe_ratio: 19.0 }
         end
@@ -228,17 +230,21 @@ RSpec.describe FinancialDataProviders::BaseProvider, type: :model do
 
     before { Rails.cache.clear }
 
-    it 'converts GBp prices to GBP and divides every monetary field by 100' do
+    it 'converts GBp prices to GBP and divides price-family fields by 100' do
       stock = gbp_provider.get_stock('DGE.L')
       expect(stock.currency).to eq('GBP')
       # price is stored as decimal(10, 2), so 15.295 rounds to 15.30
       expect(stock.price.to_f).to be_within(0.01).of(15.30)
-      expect(stock.eps.to_f).to eq(0.8)
-      expect(stock.dividend.to_f).to eq(0.6)
       expect(stock.ma_50.to_f).to eq(15.0)
       expect(stock.ma_200.to_f).to eq(14.5)
       expect(stock.fifty_two_week_high.to_f).to eq(18.0)
       expect(stock.fifty_two_week_low.to_f).to eq(12.0)
+    end
+
+    it 'leaves dividend and EPS alone (Yahoo returns them in the major unit)' do
+      stock = gbp_provider.get_stock('DGE.L')
+      expect(stock.dividend.to_f).to eq(0.63)
+      expect(stock.eps.to_f).to eq(0.80)
     end
 
     it 'leaves yield/payout/PE ratios untouched (they are unitless)' do


### PR DESCRIPTION
## Summary
Bug fix for the multi-currency dividend calendar.

For listings quoted in a minor unit (DGE.L in GBp, ZAc, ILA), Yahoo returns the price-family fields (`regularMarketPrice`, `fiftyDayAverage`, `twoHundredDayAverage`, `fiftyTwoWeekHigh/Low`) in the minor unit — but `dividendRate` and `epsTrailingTwelveMonths` already come back in the **major** unit. Our `normalize_minor_unit_currency` was applying the divide-by-100 to every field in `PRICE_FIELDS`, shrinking Diageo's £0.63 dividend to £0.0063 — which the dividend calendar then formatted as `£0.00` on the per-row cell.

Verified against live data:

\`\`\`
Stock.find_by(symbol: "DGE.L")
# => price: 15.30 (correct), dividend: 0.0063 (wrong), eps: 0.008 (wrong)
\`\`\`

Fix: drop `:dividend` and `:eps` from `PRICE_FIELDS`. Only the price-family fields get the pence→pound division now.

## Post-deploy
Run a stock refresh so the cached rows pick up the corrected values:

\`\`\`
bin/kamal app exec "bin/rails runner 'RefreshStocksJob.perform_now(force: true)'"
\`\`\`

(or wait for the nightly job — but the bad rows will keep showing wrong dividend numbers until then.)

## Test plan
- [x] `bundle exec rspec` — full suite 0 failures (spec updated to reflect Yahoo's actual unit behaviour).
- [x] `bin/rubocop` — clean.
- [ ] After deploy + refresh: confirm DGE.L row in the dividend calendar shows the real per-payment figure (e.g. ~£0.32 for a semi-annual £0.63 annual div), and the per-share total on the radar reflects it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)