### PR TITLE
Pass company_name to the logo service

### DIFF
--- a/app/frontend/components/StockLogo.tsx
+++ b/app/frontend/components/StockLogo.tsx
@@ -65,9 +65,18 @@ function getInitials(symbol: string): string {
 /**
  * Build logo-service URL for a stock ticker.
  * The API key is passed as a query param so it works in <img src> tags.
+ * `name` is forwarded as `company_name` so the service's LLM fallback can
+ * disambiguate exchange-suffixed tickers (REP.MC → Repsol).
  */
-function getLogoServiceUrl(symbol: string, serviceUrl: string, apiKey: string, size: string): string {
-  return `${serviceUrl}/api/v1/logos/${symbol.toUpperCase()}?size=${size}&api_key=${apiKey}`
+function getLogoServiceUrl(
+  symbol: string,
+  serviceUrl: string,
+  apiKey: string,
+  size: string,
+  name?: string,
+): string {
+  const base = `${serviceUrl}/api/v1/logos/${symbol.toUpperCase()}?size=${size}&api_key=${apiKey}`
+  return name ? `${base}&company_name=${encodeURIComponent(name)}` : base
 }
 
 /**
@@ -123,7 +132,7 @@ export function StockLogo({ symbol, name, size = 'md', className = '' }: StockLo
           {imageStatus === 'loading' && <LoadingSkeleton />}
           {imageStatus === 'error' && <InitialsFallback symbol={symbol} colorClass={colorClass} />}
           <img
-            src={getLogoServiceUrl(symbol, serviceUrl, apiKey, logoServiceSizes[size])}
+            src={getLogoServiceUrl(symbol, serviceUrl, apiKey, logoServiceSizes[size], name)}
             alt={`${name || symbol} logo`}
             className={`w-full h-full object-contain rounded-lg ${imageStatus === 'loaded' ? '' : 'hidden'}`}
             onLoad={handleLoad}


### PR DESCRIPTION
## Summary
Foreign tickers (REP.MC, DGE.L, IBE.MC) miss the GitHub repos the logo service searches and fall through to its LLM layer, which was being called with an empty company name. The component already accepted a `name` prop — this PR just plumbs it through to `&company_name=<encoded>` so the LLM has enough context to find the right brand.

Pairs with [fleveque/logo-service#13](https://github.com/fleveque/logo-service/pull/13). Safe to merge in either order:
- Logo-service is additive — accepts the param if present, ignores if absent.
- This PR sends the param; an older service deploy just ignores it.

## Test plan
- [x] `npx tsc --noEmit` — clean.
- [x] `bundle exec rspec` — 445 examples, 0 failures.
- [ ] After both PRs merge + logo-service deploys: refresh the radar/portfolio with REP.MC and DGE.L holdings; expect real logos to appear (first request triggers the LLM lookup, subsequent ones hit the local cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)