### PR TITLE
Portfolio stats + admin activity (and Pulse payload + AV parity)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -42,7 +42,7 @@ gem "timecop"
 gem "simplecov", require: false, group: :test
 
 # Financial data providers (You can just pick one and comment out the others)
-gem "yahoo_finance_client", "~> 0.7.0"
+gem "yahoo_finance_client", "~> 0.8.0"
 gem "alphavantage"
 
 # NATS messaging

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -469,7 +469,7 @@ GEM
     websocket-extensions (0.1.5)
     xpath (3.2.0)
       nokogiri (~> 1.8)
-    yahoo_finance_client (0.7.0)
+    yahoo_finance_client (0.8.0)
       csv
       httparty (~> 0.21.0)
     zeitwerk (2.7.3)
@@ -518,7 +518,7 @@ DEPENDENCIES
   tzinfo-data
   vite_rails
   web-console
-  yahoo_finance_client (~> 0.7.0)
+  yahoo_finance_client (~> 0.8.0)
 
 BUNDLED WITH
    2.6.2

--- a/app/controllers/api/v1/admin/dashboard_controller.rb
+++ b/app/controllers/api/v1/admin/dashboard_controller.rb
@@ -2,6 +2,8 @@ module Api
   module V1
     module Admin
       class DashboardController < BaseController
+        SESSION_TREND_WEEKS = 8
+
         # GET /api/v1/admin/dashboard
         def show
           users_with_holdings = User.joins(:holdings).distinct.count
@@ -39,8 +41,49 @@ module Api
             pulse: {
               usersWithSlug: users_with_slug,
               adoptionRate: User.count.positive? ? (users_with_slug.to_f / User.count * 100).round(1) : 0
-            }
+            },
+            activity: activity_payload
           })
+        end
+
+        private
+
+        def activity_payload
+          {
+            activeUsers7d: active_users_in(7),
+            activeUsers30d: active_users_in(30),
+            holdingChanges7d: holding_changes_in(7),
+            holdingChanges30d: holding_changes_in(30),
+            usersTouchingHoldings7d: users_touching_holdings_in(7),
+            sessionTrend: session_trend
+          }
+        end
+
+        def active_users_in(days)
+          Session.where("updated_at > ?", days.days.ago).distinct.count(:user_id)
+        end
+
+        def holding_changes_in(days)
+          Holding.where("updated_at > ? OR created_at > ?", days.days.ago, days.days.ago).count
+        end
+
+        def users_touching_holdings_in(days)
+          Holding.where("updated_at > ? OR created_at > ?", days.days.ago, days.days.ago).distinct.count(:user_id)
+        end
+
+        # Weekly buckets of session creations for the last N weeks. Returns an
+        # ordered array of { weekStart: "2026-05-11", count: Integer } — week
+        # starts on Monday (ISO week convention).
+        def session_trend
+          window_start = SESSION_TREND_WEEKS.weeks.ago.beginning_of_week
+          counts = Session.where("created_at >= ?", window_start)
+                          .group_by { |s| s.created_at.to_date.beginning_of_week }
+                          .transform_values(&:size)
+
+          (0...SESSION_TREND_WEEKS).map do |i|
+            week_start = (window_start + i.weeks).to_date
+            { weekStart: week_start.iso8601, count: counts[week_start] || 0 }
+          end
         end
       end
     end

--- a/app/controllers/api/v1/holdings_controller.rb
+++ b/app/controllers/api/v1/holdings_controller.rb
@@ -25,7 +25,8 @@ module Api
         render_success({
           holdings: serialized,
           totalsByCurrency: totals_by_currency_payload(totals),
-          displayTotal: display_total_payload(totals)
+          displayTotal: display_total_payload(totals),
+          portfolioStats: PortfolioStatsService.call(Current.user)
         })
       end
 

--- a/app/frontend/components/PortfolioStatsCard.tsx
+++ b/app/frontend/components/PortfolioStatsCard.tsx
@@ -1,0 +1,118 @@
+import { useTranslation } from 'react-i18next'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+import type { PortfolioStats } from '../types'
+
+interface PortfolioStatsCardProps {
+  stats: PortfolioStats | null | undefined
+}
+
+// Color palette for sector segments — tailwind-friendly, dark-mode aware.
+const SECTOR_COLORS = [
+  'bg-emerald-500',
+  'bg-blue-500',
+  'bg-amber-500',
+  'bg-purple-500',
+  'bg-rose-500',
+  'bg-cyan-500',
+  'bg-indigo-500',
+  'bg-orange-500',
+  'bg-lime-500',
+  'bg-pink-500',
+  'bg-slate-400',
+]
+
+export function PortfolioStatsCard({ stats }: PortfolioStatsCardProps) {
+  const { t } = useTranslation()
+  if (!stats) return null
+
+  const hasDisplay = stats.displayYoc !== null && stats.displayCurrentYield !== null
+
+  return (
+    <Card>
+      <CardHeader className="pb-3">
+        <CardTitle className="text-lg">{t('portfolio.stats.title')}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <YieldRow stats={stats} hasDisplay={hasDisplay} />
+        {stats.sectors.length > 0 && <SectorBreakdown sectors={stats.sectors} />}
+      </CardContent>
+    </Card>
+  )
+}
+
+function YieldRow({ stats, hasDisplay }: { stats: PortfolioStats; hasDisplay: boolean }) {
+  const { t } = useTranslation()
+  if (hasDisplay) {
+    return (
+      <div className="grid grid-cols-2 gap-4">
+        <Metric label={t('portfolio.stats.yieldOnCost')} value={`${stats.displayYoc!.toFixed(2)}%`} />
+        <Metric label={t('portfolio.stats.currentYield')} value={`${stats.displayCurrentYield!.toFixed(2)}%`} />
+      </div>
+    )
+  }
+  // FX unavailable → fall back to per-currency rows.
+  const entries = Object.entries(stats.byCurrency)
+  return (
+    <div className="space-y-2 text-sm">
+      <p className="text-xs text-muted-foreground">{t('portfolio.stats.perCurrencyFallback')}</p>
+      {entries.map(([code, y]) => (
+        <div key={code} className="flex items-center justify-between gap-4">
+          <span className="font-mono text-xs text-muted-foreground">{code}</span>
+          <div className="flex gap-4">
+            <Metric inline label={t('portfolio.stats.yieldOnCost')} value={`${y.yoc.toFixed(2)}%`} />
+            <Metric inline label={t('portfolio.stats.currentYield')} value={`${y.currentYield.toFixed(2)}%`} />
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+function Metric({ label, value, inline }: { label: string; value: string; inline?: boolean }) {
+  if (inline) {
+    return (
+      <span className="text-sm">
+        <span className="text-muted-foreground">{label}: </span>
+        <span className="font-semibold">{value}</span>
+      </span>
+    )
+  }
+  return (
+    <div>
+      <p className="text-xs text-muted-foreground">{label}</p>
+      <p className="text-2xl font-bold text-foreground">{value}</p>
+    </div>
+  )
+}
+
+function SectorBreakdown({ sectors }: { sectors: PortfolioStats['sectors'] }) {
+  const { t } = useTranslation()
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs text-muted-foreground">{t('portfolio.stats.sectors')}</p>
+      <div className="flex h-3 w-full overflow-hidden rounded-md">
+        {sectors.map((s, i) => (
+          <div
+            key={s.sector}
+            className={cn('h-full', SECTOR_COLORS[i % SECTOR_COLORS.length])}
+            style={{ width: `${s.percent}%` }}
+            title={`${s.sector}: ${s.percent.toFixed(1)}%`}
+          />
+        ))}
+      </div>
+      <ul className="flex flex-wrap gap-x-4 gap-y-1 text-xs">
+        {sectors.map((s, i) => (
+          <li key={s.sector} className="flex items-center gap-2">
+            <span className={cn('size-2 rounded-sm', SECTOR_COLORS[i % SECTOR_COLORS.length])} />
+            <span className="text-foreground">{s.sector}</span>
+            <span className="text-muted-foreground">{s.percent.toFixed(1)}%</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+export default PortfolioStatsCard

--- a/app/frontend/locales/en.ts
+++ b/app/frontend/locales/en.ts
@@ -161,6 +161,13 @@ const en = {
     failedToLoadPortfolio: 'Failed to load portfolio',
     failedToRemoveHolding: 'Failed to remove holding',
     dividendCalendar: 'Dividend Calendar',
+    stats: {
+      title: 'Portfolio stats',
+      yieldOnCost: 'Yield on Cost',
+      currentYield: 'Current Yield',
+      sectors: 'Sectors',
+      perCurrencyFallback: 'Converted total unavailable — showing per-currency values.',
+    },
   },
 
   // Stock metrics (shared across card types)
@@ -276,6 +283,15 @@ const en = {
     stockData: 'Stock Data',
     tools: 'Tools',
     openContentDrafts: 'Social-media drafts',
+    activity: {
+      title: 'Activity',
+      activeUsers7d: 'Active users (7d)',
+      activeUsers30d: 'Active users (30d)',
+      holdingChanges7d: 'Holding changes (7d)',
+      holdingChanges30d: 'Holding changes (30d)',
+      usersTouchingHoldings7d: 'Users editing (7d)',
+      sessionTrend: 'New sessions per week (last 8 weeks)',
+    },
     users: 'Users',
     totalUsers: 'Total Users',
     admins: 'Admins',

--- a/app/frontend/locales/es.ts
+++ b/app/frontend/locales/es.ts
@@ -161,6 +161,13 @@ const es = {
     failedToLoadPortfolio: 'Error al cargar la cartera',
     failedToRemoveHolding: 'Error al eliminar posici\u00f3n',
     dividendCalendar: 'Calendario de Dividendos',
+    stats: {
+      title: 'M\u00e9tricas de cartera',
+      yieldOnCost: 'YoC (yield sobre coste)',
+      currentYield: 'Yield actual',
+      sectors: 'Sectores',
+      perCurrencyFallback: 'Total convertido no disponible \u2014 mostrando valores por divisa.',
+    },
   },
 
   // Stock metrics
@@ -275,6 +282,15 @@ const es = {
     stockData: 'Datos de Acciones',
     tools: 'Herramientas',
     openContentDrafts: 'Borradores para redes',
+    activity: {
+      title: 'Actividad',
+      activeUsers7d: 'Usuarios activos (7d)',
+      activeUsers30d: 'Usuarios activos (30d)',
+      holdingChanges7d: 'Cambios en cartera (7d)',
+      holdingChanges30d: 'Cambios en cartera (30d)',
+      usersTouchingHoldings7d: 'Usuarios editando (7d)',
+      sessionTrend: 'Nuevas sesiones por semana (últimas 8 semanas)',
+    },
     users: 'Usuarios',
     totalUsers: 'Usuarios Totales',
     admins: 'Administradores',

--- a/app/frontend/pages/AdminDashboardPage.tsx
+++ b/app/frontend/pages/AdminDashboardPage.tsx
@@ -43,6 +43,36 @@ function StatCard({ label, value }: { label: string; value: string | number }) {
   )
 }
 
+interface SessionTrendBucket {
+  weekStart: string
+  count: number
+}
+
+function SessionTrend({ buckets }: { buckets: SessionTrendBucket[] }) {
+  const { t, i18n } = useTranslation()
+  const max = Math.max(1, ...buckets.map((b) => b.count))
+
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <p className="text-muted-foreground text-sm mb-3">{t('admin.activity.sessionTrend')}</p>
+        <div className="flex items-end gap-1 h-24">
+          {buckets.map((b) => {
+            const pct = Math.max(2, Math.round((b.count / max) * 100))
+            const dateLabel = new Date(b.weekStart).toLocaleDateString(i18n.language, { month: 'short', day: 'numeric' })
+            return (
+              <div key={b.weekStart} className="flex-1 flex flex-col items-center gap-1" title={`${dateLabel}: ${b.count}`}>
+                <div className="w-full bg-blue-500 rounded-sm" style={{ height: `${pct}%` }} />
+                <span className="text-[10px] text-muted-foreground font-mono">{dateLabel}</span>
+              </div>
+            )
+          })}
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
 function UserRow({
   user,
   onDelete,
@@ -182,6 +212,21 @@ export function AdminDashboardPage() {
           </div>
         )}
       </section>
+
+      {/* Activity Section */}
+      {stats?.activity && (
+        <section className="mb-10">
+          <h2 className="text-xl font-semibold text-foreground mb-4">{t('admin.activity.title')}</h2>
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-4 mb-4">
+            <StatCard label={t('admin.activity.activeUsers7d')} value={stats.activity.activeUsers7d} />
+            <StatCard label={t('admin.activity.activeUsers30d')} value={stats.activity.activeUsers30d} />
+            <StatCard label={t('admin.activity.holdingChanges7d')} value={stats.activity.holdingChanges7d} />
+            <StatCard label={t('admin.activity.holdingChanges30d')} value={stats.activity.holdingChanges30d} />
+            <StatCard label={t('admin.activity.usersTouchingHoldings7d')} value={stats.activity.usersTouchingHoldings7d} />
+          </div>
+          <SessionTrend buckets={stats.activity.sessionTrend} />
+        </section>
+      )}
 
       {/* Stock Refresh Section */}
       <section className="mb-10">

--- a/app/frontend/pages/PortfolioPage.tsx
+++ b/app/frontend/pages/PortfolioPage.tsx
@@ -7,6 +7,7 @@ import { ViewToggle } from '../components/ViewToggle'
 import { SearchResultCard } from '../components/SearchResultCard'
 import { DividendCalendar } from '../components/DividendCalendar'
 import { PortfolioInsights } from '../components/PortfolioInsights'
+import { PortfolioStatsCard } from '../components/PortfolioStatsCard'
 import { useHoldings, useCreateHolding, useDeleteHolding } from '../hooks/useHoldingsQueries'
 import { useStockSearch, useResolveStock } from '../hooks/useStockQueries'
 import { useViewPreference } from '../contexts/ViewPreferenceContext'
@@ -440,6 +441,13 @@ export function PortfolioPage() {
           </div>
         </CardContent>
       </Card>
+
+      {/* Portfolio Stats */}
+      {holdings.length > 0 && holdingsData?.portfolioStats && (
+        <div className="mt-6">
+          <PortfolioStatsCard stats={holdingsData.portfolioStats} />
+        </div>
+      )}
 
       {/* AI Portfolio Insights */}
       {holdings.length > 0 && (

--- a/app/frontend/types/index.ts
+++ b/app/frontend/types/index.ts
@@ -144,10 +144,30 @@ export interface DisplayTotal {
   conversions: Record<string, number>
 }
 
+export interface CurrencyYield {
+  yoc: number
+  currentYield: number
+}
+
+export interface SectorBreakdown {
+  sector: string
+  value: number
+  percent: number
+}
+
+export interface PortfolioStats {
+  byCurrency: Record<string, CurrencyYield>
+  displayCurrency: string
+  displayYoc: number | null
+  displayCurrentYield: number | null
+  sectors: SectorBreakdown[]
+}
+
 export interface HoldingsResponse {
   holdings: Holding[]
   totalsByCurrency: Record<string, CurrencyTotals>
   displayTotal: DisplayTotal | null
+  portfolioStats: PortfolioStats | null
 }
 
 export interface UserProfile {
@@ -291,6 +311,14 @@ export interface AdminDashboardStats {
   pulse: {
     usersWithSlug: number
     adoptionRate: number
+  }
+  activity: {
+    activeUsers7d: number
+    activeUsers30d: number
+    holdingChanges7d: number
+    holdingChanges30d: number
+    usersTouchingHoldings7d: number
+    sessionTrend: { weekStart: string; count: number }[]
   }
 }
 

--- a/app/services/financial_data_providers/alpha_vantage_fx_provider.rb
+++ b/app/services/financial_data_providers/alpha_vantage_fx_provider.rb
@@ -1,0 +1,36 @@
+module FinancialDataProviders
+  # FX-pair lookup via Alpha Vantage's CURRENCY_EXCHANGE_RATE endpoint. Mirrors
+  # the contract `FxRateService` expects from the Yahoo-backed default:
+  # `get_fx_rate(from, to)` returns a `Float` (one unit of `from` in `to`) or
+  # `nil` on any failure.
+  #
+  # Wired in via `Rails.application.config.fx_rate_provider` when the active
+  # stock provider is `:alpha_vantage`, so callers don't change.
+  #
+  # Caveat: AV's free tier is 25 requests/day shared across ALL endpoints —
+  # both stock refreshes and FX lookups draw from the same bucket. If you're
+  # on AV's free tier, expect FX pairs to be rate-limited; FxRateService's
+  # DB-backed cache (`STALE_AFTER = 24.hours`) absorbs that under normal use.
+  class AlphaVantageFxProvider
+    BASE_URL = "https://www.alphavantage.co/query"
+
+    class << self
+      def get_fx_rate(from, to)
+        return 1.0 if from == to
+
+        api_key = ENV["ALPHAVANTAGE_API_KEY"]
+        return nil if api_key.blank?
+
+        response = HTTParty.get(BASE_URL, query: {
+          function: "CURRENCY_EXCHANGE_RATE", from_currency: from, to_currency: to, apikey: api_key
+        }, timeout: 15)
+
+        rate = response.parsed_response.dig("Realtime Currency Exchange Rate", "5. Exchange Rate")
+        rate&.to_f
+      rescue StandardError => e
+        Rails.logger.warn "AlphaVantage FX error #{from}->#{to}: #{e.message}"
+        nil
+      end
+    end
+  end
+end

--- a/app/services/financial_data_providers/alpha_vantage_provider.rb
+++ b/app/services/financial_data_providers/alpha_vantage_provider.rb
@@ -58,6 +58,8 @@ module FinancialDataProviders
         price: quote_data.price,
         currency: overview&.dig("Currency"),
         name: overview&.dig("Name"),
+        sector: overview&.dig("Sector").presence,
+        industry: overview&.dig("Industry").presence,
         eps: parse_decimal(overview&.dig("EPS")),
         pe_ratio: parse_decimal(overview&.dig("PERatio")),
         dividend: parse_decimal(overview&.dig("DividendPerShare")),

--- a/app/services/financial_data_providers/base_provider.rb
+++ b/app/services/financial_data_providers/base_provider.rb
@@ -2,7 +2,7 @@ module FinancialDataProviders
   class BaseProvider
     REQUIRED_FIELDS = [ :symbol, :price ].freeze
     OPTIONAL_FIELDS = [
-      :name, :currency, :eps, :pe_ratio, :dividend, :dividend_yield,
+      :name, :currency, :sector, :industry, :eps, :pe_ratio, :dividend, :dividend_yield,
       :payout_ratio, :ma_50, :ma_200, :fifty_two_week_high, :fifty_two_week_low,
       :ex_dividend_date, :payment_frequency, :payment_months, :shifted_payment_months
     ].freeze

--- a/app/services/financial_data_providers/yahoo_finance_provider.rb
+++ b/app/services/financial_data_providers/yahoo_finance_provider.rb
@@ -7,7 +7,8 @@ module FinancialDataProviders
       normalized = normalize_yahoo_data(data)
       return nil unless normalized
 
-      enrich_with_dividend_schedule(normalized, symbol)
+      enriched = enrich_with_dividend_schedule(normalized, symbol)
+      enrich_with_quote_summary(enriched, symbol)
     rescue StandardError => e
       Rails.logger.error "Yahoo Finance API error: #{e.message}"
       nil
@@ -26,7 +27,8 @@ module FinancialDataProviders
         normalized = normalize_yahoo_data(quotes[symbol])
         next nil unless normalized
 
-        enrich_with_dividend_schedule(normalized, symbol)
+        enriched = enrich_with_dividend_schedule(normalized, symbol)
+        enrich_with_quote_summary(enriched, symbol)
       end
     rescue StandardError => e
       Rails.logger.error "Yahoo Finance bulk API error: #{e.message}"
@@ -72,6 +74,21 @@ module FinancialDataProviders
     rescue StandardError => e
       Rails.logger.warn "Yahoo Finance dividend history error for #{symbol}: #{e.message}"
       []
+    end
+
+    # Sector/industry barely change. Only call the extra endpoint when we don't
+    # already have the data — saves an HTTP roundtrip on every refresh.
+    def enrich_with_quote_summary(data, symbol)
+      existing = Stock.find_by(symbol: symbol.upcase.strip)
+      return data if existing&.sector.present?
+
+      profile = YahooFinanceClient::Stock.get_quote_summary(symbol)
+      return data unless profile
+
+      data.merge(sector: profile[:sector], industry: profile[:industry])
+    rescue StandardError => e
+      Rails.logger.warn "Yahoo Finance quoteSummary error for #{symbol}: #{e.message}"
+      data
     end
   end
 end

--- a/app/services/portfolio_payload_builder.rb
+++ b/app/services/portfolio_payload_builder.rb
@@ -13,7 +13,22 @@ module PortfolioPayloadBuilder
       version: PAYLOAD_VERSION,
       slug: user.portfolio_slug,
       base_currency: base_currency,
-      holdings: user.holdings.includes(:stock).map { |h| serialize_holding(h, base_currency) }
+      holdings: user.holdings.includes(:stock).map { |h| serialize_holding(h, base_currency) },
+      stats: stats_for(user)
+    }
+  end
+
+  # Pre-aggregated stats so Pulse doesn't have to redo the per-currency / FX
+  # math in Elixir. nil when the portfolio is empty (PortfolioStatsService
+  # short-circuits in that case).
+  def stats_for(user)
+    stats = PortfolioStatsService.call(user)
+    return nil if stats.nil?
+
+    {
+      yoc: stats[:displayYoc],
+      currentYield: stats[:displayCurrentYield],
+      sectors: stats[:sectors]
     }
   end
 

--- a/app/services/portfolio_stats_service.rb
+++ b/app/services/portfolio_stats_service.rb
@@ -1,0 +1,126 @@
+class PortfolioStatsService
+  UNKNOWN_SECTOR = "Unknown".freeze
+
+  # Returns the portfolio-stats payload for a user, or nil for an empty portfolio.
+  # Shape:
+  #   {
+  #     byCurrency: { "USD" => { yoc: 3.2, currentYield: 2.8 }, "EUR" => {...} },
+  #     displayCurrency: "USD",
+  #     displayYoc: 3.0,             # nil if any FX missing
+  #     displayCurrentYield: 2.6,    # nil if any FX missing
+  #     sectors: [
+  #       { sector: "Technology", value: 12300.45, percent: 42.1 },
+  #       ...
+  #     ]                            # [] when no sector data or FX missing
+  #   }
+  def self.call(user)
+    holdings = user.holdings.includes(:stock).to_a
+    return nil if holdings.empty?
+
+    new(user, holdings).call
+  end
+
+  def initialize(user, holdings)
+    @user = user
+    @holdings = holdings
+    @preferred = user.preferred_currency || "USD"
+  end
+
+  def call
+    by_currency = compute_by_currency
+    display = compute_display_aggregates
+
+    {
+      byCurrency: by_currency,
+      displayCurrency: @preferred,
+      displayYoc: display[:yoc],
+      displayCurrentYield: display[:current_yield],
+      sectors: compute_sectors
+    }
+  end
+
+  private
+
+  attr_reader :user, :holdings, :preferred
+
+  def compute_by_currency
+    grouped = holdings.group_by { |h| h.stock.currency || "USD" }
+    grouped.transform_values do |hs|
+      annual_income = hs.sum { |h| holding_annual_income(h) }
+      cost_basis    = hs.sum { |h| holding_cost_basis(h) }
+      market_value  = hs.sum { |h| holding_market_value(h) }
+
+      {
+        yoc: percentage(annual_income, cost_basis),
+        currentYield: percentage(annual_income, market_value)
+      }
+    end
+  end
+
+  def compute_display_aggregates
+    converted_income = 0.0
+    converted_cost = 0.0
+    converted_value = 0.0
+
+    holdings.each do |h|
+      from = h.stock.currency || "USD"
+      income = FxRateService.convert(holding_annual_income(h), from: from, to: preferred)
+      cost   = FxRateService.convert(holding_cost_basis(h), from: from, to: preferred)
+      value  = FxRateService.convert(holding_market_value(h), from: from, to: preferred)
+
+      return { yoc: nil, current_yield: nil } if income.nil? || cost.nil? || value.nil?
+
+      converted_income += income.to_f
+      converted_cost   += cost.to_f
+      converted_value  += value.to_f
+    end
+
+    {
+      yoc: percentage(converted_income, converted_cost),
+      current_yield: percentage(converted_income, converted_value)
+    }
+  end
+
+  def compute_sectors
+    return [] unless holdings.any? { |h| h.stock.sector.present? }
+
+    grouped = holdings.group_by { |h| h.stock.sector.presence || UNKNOWN_SECTOR }
+
+    converted = grouped.transform_values do |hs|
+      hs.sum do |h|
+        from = h.stock.currency || "USD"
+        v = FxRateService.convert(holding_market_value(h), from: from, to: preferred)
+        return [] if v.nil? # any FX miss → skip the whole section
+
+        v.to_f
+      end
+    end
+
+    total = converted.values.sum
+    return [] if total.zero?
+
+    converted
+      .sort_by { |_, v| -v }
+      .map { |sector, value| { sector: sector, value: value.round(2), percent: (value / total * 100).round(1) } }
+  end
+
+  def holding_annual_income(holding)
+    return 0.0 unless holding.stock.dividend
+
+    holding.stock.dividend.to_f * holding.quantity.to_f
+  end
+
+  def holding_cost_basis(holding)
+    holding.average_price.to_f * holding.quantity.to_f
+  end
+
+  def holding_market_value(holding)
+    (holding.stock.price || 0).to_f * holding.quantity.to_f
+  end
+
+  def percentage(numerator, denominator)
+    return 0.0 if denominator.zero?
+
+    (numerator / denominator * 100).round(2)
+  end
+end

--- a/config/initializers/financial_data_provider.rb
+++ b/config/initializers/financial_data_provider.rb
@@ -6,12 +6,16 @@ module FinancialDataProvider
         Alphavantage.configure do |c|
           c.api_key = ENV["ALPHAVANTAGE_API_KEY"]
         end
+        # Use AV's CURRENCY_EXCHANGE_RATE endpoint for FX so the whole stack
+        # speaks the same provider when AV is the active stock source.
+        config.fx_rate_provider = FinancialDataProviders::AlphaVantageFxProvider
       }
     },
     yahoo_finance: {
       gem: "yahoo_finance_client",
       config: ->(config) {
-        # Add Yahoo Finance specific configuration if needed
+        # FxRateService falls back to YahooFinanceClient::Stock when no
+        # `fx_rate_provider` is configured — nothing to set here.
       }
     }
   }.freeze

--- a/db/migrate/20260517150000_add_sector_to_stocks.rb
+++ b/db/migrate/20260517150000_add_sector_to_stocks.rb
@@ -1,0 +1,6 @@
+class AddSectorToStocks < ActiveRecord::Migration[8.0]
+  def change
+    add_column :stocks, :sector, :string
+    add_column :stocks, :industry, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_17_100000) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_17_150000) do
   create_table "buy_plan_items", force: :cascade do |t|
     t.integer "buy_plan_id", null: false
     t.integer "stock_id", null: false
@@ -119,6 +119,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_17_100000) do
     t.decimal "fifty_two_week_high", precision: 10, scale: 2
     t.decimal "fifty_two_week_low", precision: 10, scale: 2
     t.string "currency", default: "USD", null: false
+    t.string "sector"
+    t.string "industry"
     t.index ["symbol"], name: "index_stocks_on_symbol", unique: true
   end
 

--- a/spec/factories/sessions.rb
+++ b/spec/factories/sessions.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :session do
+    user
+    ip_address { "127.0.0.1" }
+    user_agent { "RSpec Test Agent" }
+  end
+end

--- a/spec/requests/api/v1/admin/dashboard_spec.rb
+++ b/spec/requests/api/v1/admin/dashboard_spec.rb
@@ -63,6 +63,36 @@ RSpec.describe "Api::V1::Admin::Dashboard", type: :request do
         expect(data["pulse"]["usersWithSlug"]).to eq(1)
         expect(data["pulse"]["adoptionRate"]).to be > 0
       end
+
+      describe "activity section" do
+        it "exposes active-user, holding-change, and session-trend metrics" do
+          # Sessions: one recent (last 7d), one older (between 7-30d), one stale.
+          fresh   = create(:user)
+          warm    = create(:user)
+          old     = create(:user)
+          create(:session, user: fresh, created_at: 2.days.ago, updated_at: 2.days.ago)
+          create(:session, user: warm,  created_at: 15.days.ago, updated_at: 15.days.ago)
+          create(:session, user: old,   created_at: 90.days.ago, updated_at: 90.days.ago)
+
+          # Holding changes: one recent, one older.
+          stock = create(:stock, symbol: "AAPL", price: 150.00)
+          create(:holding, user: fresh, stock: stock, quantity: 1, average_price: 100, created_at: 1.day.ago, updated_at: 1.day.ago)
+
+          get "/api/v1/admin/dashboard"
+
+          act = JSON.parse(response.body)["data"]["activity"]
+          # Admin's own sign_in creates a fresh session, so 7d active count includes admin + fresh user.
+          expect(act["activeUsers7d"]).to be >= 2
+          expect(act["activeUsers30d"]).to be >= 3
+          expect(act["holdingChanges7d"]).to be >= 1
+          expect(act["usersTouchingHoldings7d"]).to eq(1)
+          expect(act["sessionTrend"]).to be_an(Array)
+          expect(act["sessionTrend"].size).to eq(8)
+          act["sessionTrend"].each do |bucket|
+            expect(bucket).to include("weekStart", "count")
+          end
+        end
+      end
     end
   end
 end

--- a/spec/requests/api/v1/holdings_spec.rb
+++ b/spec/requests/api/v1/holdings_spec.rb
@@ -104,6 +104,27 @@ RSpec.describe "Api::V1::Holdings", type: :request do
           expect(json["data"]["displayTotal"]).to be_nil
         end
       end
+
+      describe "portfolioStats" do
+        it "returns nil for an empty portfolio" do
+          get "/api/v1/holdings"
+          expect(JSON.parse(response.body)["data"]["portfolioStats"]).to be_nil
+        end
+
+        it "returns YoC, current yield, and sectors for a non-empty portfolio" do
+          dividend_stock = create(:stock, symbol: "DIV", currency: "USD", price: 100.0, dividend: 5.0, sector: "Energy")
+          create(:holding, user: user, stock: dividend_stock, quantity: 10, average_price: 80.0)
+
+          get "/api/v1/holdings"
+          stats = JSON.parse(response.body)["data"]["portfolioStats"]
+
+          expect(stats["byCurrency"]["USD"]["yoc"]).to be_within(0.01).of(6.25)            # 50 / 800
+          expect(stats["byCurrency"]["USD"]["currentYield"]).to be_within(0.01).of(5.0)    # 50 / 1000
+          expect(stats["displayYoc"]).to be_within(0.01).of(6.25)
+          expect(stats["sectors"].first["sector"]).to eq("Energy")
+          expect(stats["sectors"].first["percent"]).to eq(100.0)
+        end
+      end
     end
   end
 

--- a/spec/services/financial_data_providers/alpha_vantage_fx_provider_spec.rb
+++ b/spec/services/financial_data_providers/alpha_vantage_fx_provider_spec.rb
@@ -1,0 +1,87 @@
+require 'rails_helper'
+
+RSpec.describe FinancialDataProviders::AlphaVantageFxProvider do
+  before { allow(ENV).to receive(:[]).and_call_original }
+
+  describe '.get_fx_rate' do
+    context 'identity pair' do
+      it 'returns 1.0 without an API call' do
+        expect(HTTParty).not_to receive(:get)
+        expect(described_class.get_fx_rate("USD", "USD")).to eq(1.0)
+      end
+    end
+
+    context 'missing API key' do
+      before { allow(ENV).to receive(:[]).with("ALPHAVANTAGE_API_KEY").and_return(nil) }
+
+      it 'returns nil without calling out' do
+        expect(HTTParty).not_to receive(:get)
+        expect(described_class.get_fx_rate("EUR", "USD")).to be_nil
+      end
+    end
+
+    context 'valid response' do
+      let(:response) do
+        instance_double(
+          HTTParty::Response,
+          parsed_response: {
+            "Realtime Currency Exchange Rate" => {
+              "1. From_Currency Code" => "EUR",
+              "3. To_Currency Code" => "USD",
+              "5. Exchange Rate" => "1.0823"
+            }
+          }
+        )
+      end
+
+      before do
+        allow(ENV).to receive(:[]).with("ALPHAVANTAGE_API_KEY").and_return("test_key")
+        allow(HTTParty).to receive(:get).and_return(response)
+      end
+
+      it 'returns the parsed rate as a Float' do
+        expect(described_class.get_fx_rate("EUR", "USD")).to eq(1.0823)
+      end
+
+      it 'sends from/to currency codes + api key in the query' do
+        described_class.get_fx_rate("EUR", "USD")
+        expect(HTTParty).to have_received(:get).with(
+          described_class::BASE_URL,
+          hash_including(query: hash_including(
+            function: "CURRENCY_EXCHANGE_RATE",
+            from_currency: "EUR",
+            to_currency: "USD",
+            apikey: "test_key"
+          ))
+        )
+      end
+    end
+
+    context 'response missing the rate field (rate-limited / bad symbol)' do
+      let(:response) do
+        instance_double(HTTParty::Response, parsed_response: { "Note" => "API call frequency..." })
+      end
+
+      before do
+        allow(ENV).to receive(:[]).with("ALPHAVANTAGE_API_KEY").and_return("test_key")
+        allow(HTTParty).to receive(:get).and_return(response)
+      end
+
+      it 'returns nil' do
+        expect(described_class.get_fx_rate("EUR", "USD")).to be_nil
+      end
+    end
+
+    context 'HTTP error' do
+      before do
+        allow(ENV).to receive(:[]).with("ALPHAVANTAGE_API_KEY").and_return("test_key")
+        allow(HTTParty).to receive(:get).and_raise(StandardError, "boom")
+      end
+
+      it 'returns nil and logs' do
+        expect(Rails.logger).to receive(:warn).with(/AlphaVantage FX error EUR->USD/)
+        expect(described_class.get_fx_rate("EUR", "USD")).to be_nil
+      end
+    end
+  end
+end

--- a/spec/services/financial_data_providers/alpha_vantage_provider_spec.rb
+++ b/spec/services/financial_data_providers/alpha_vantage_provider_spec.rb
@@ -103,6 +103,35 @@ RSpec.describe FinancialDataProviders::AlphaVantageProvider, type: :model do
         provider.get_stock(symbol)
         expect(stock).to have_received(:update!).with(hash_including(currency: "USD"))
       end
+
+      context 'when overview includes Sector and Industry' do
+        let(:overview_data) do
+          {
+            "Name" => "Apple Inc.",
+            "Currency" => "USD",
+            "Sector" => "TECHNOLOGY",
+            "Industry" => "ELECTRONIC COMPUTERS",
+            "ExDividendDate" => "2024-03-14"
+          }
+        end
+
+        it 'persists sector and industry' do
+          provider.get_stock(symbol)
+          expect(stock).to have_received(:update!).with(
+            hash_including(sector: "TECHNOLOGY", industry: "ELECTRONIC COMPUTERS")
+          )
+        end
+      end
+
+      context 'when overview has empty Sector / Industry strings' do
+        let(:overview_data) { { "Name" => "X", "Sector" => "", "Industry" => "" } }
+
+        it 'does not persist them (blank strings dropped via .presence)' do
+          provider.get_stock(symbol)
+          expect(stock).not_to have_received(:update!).with(hash_including(:sector))
+          expect(stock).not_to have_received(:update!).with(hash_including(:industry))
+        end
+      end
     end
 
     context 'when overview has no dividend data' do

--- a/spec/services/financial_data_providers/yahoo_finance_provider_spec.rb
+++ b/spec/services/financial_data_providers/yahoo_finance_provider_spec.rb
@@ -23,6 +23,7 @@ RSpec.describe FinancialDataProviders::YahooFinanceProvider, type: :model do
     before do
       allow(YahooFinanceClient::Stock).to receive(:get_quote).with(symbol).and_return(raw_data)
       allow(YahooFinanceClient::Stock).to receive(:get_dividend_history).with(symbol).and_return(dividend_history)
+      allow(YahooFinanceClient::Stock).to receive(:get_quote_summary).and_return(nil)
       allow(Stock).to receive(:find_or_initialize_by).and_return(stock)
       allow(stock).to receive(:update!).and_return(true)
 
@@ -45,6 +46,37 @@ RSpec.describe FinancialDataProviders::YahooFinanceProvider, type: :model do
           shifted_payment_months: []
         )
       )
+    end
+
+    context 'when the existing row has no sector and the quote-summary call returns one' do
+      let(:stock) { build(:stock, symbol: symbol, price: 150.00, sector: nil) }
+
+      before do
+        allow(Stock).to receive(:find_by).with(symbol: symbol.upcase.strip).and_return(stock)
+        allow(YahooFinanceClient::Stock).to receive(:get_quote_summary).with(symbol).and_return(
+          { sector: "Technology", industry: "Consumer Electronics" }
+        )
+      end
+
+      it 'persists the sector + industry' do
+        provider.get_stock(symbol)
+        expect(stock).to have_received(:update!).with(
+          hash_including(sector: "Technology", industry: "Consumer Electronics")
+        )
+      end
+    end
+
+    context 'when the existing row already has a sector' do
+      let(:stock) { build(:stock, symbol: symbol, price: 150.00, sector: "Energy") }
+
+      before do
+        allow(Stock).to receive(:find_by).with(symbol: symbol.upcase.strip).and_return(stock)
+      end
+
+      it 'skips the quote-summary call' do
+        provider.get_stock(symbol)
+        expect(YahooFinanceClient::Stock).not_to have_received(:get_quote_summary)
+      end
     end
   end
 

--- a/spec/services/portfolio_payload_builder_spec.rb
+++ b/spec/services/portfolio_payload_builder_spec.rb
@@ -86,5 +86,24 @@ RSpec.describe PortfolioPayloadBuilder do
         expect(holding[:value_in_usd]).to be_nil
       end
     end
+
+    describe 'stats block' do
+      it 'includes pre-aggregated yields + sectors so pulse renders directly' do
+        bob = create(:user, portfolio_slug: "bob")
+        div_stock = create(:stock, symbol: "DIV", currency: "USD", price: 100.0, dividend: 5.0, sector: "Energy")
+        create(:holding, user: bob, stock: div_stock, quantity: 10, average_price: 80.0)
+
+        stats = described_class.call(bob)[:stats]
+        expect(stats[:yoc]).to be_within(0.01).of(6.25)            # 50 / 800
+        expect(stats[:currentYield]).to be_within(0.01).of(5.0)    # 50 / 1000
+        expect(stats[:sectors].first[:sector]).to eq("Energy")
+        expect(stats[:sectors].first[:percent]).to eq(100.0)
+      end
+
+      it 'is nil when the user has no holdings' do
+        no_holdings_user = create(:user, portfolio_slug: "empty-#{SecureRandom.hex(4)}")
+        expect(described_class.call(no_holdings_user)[:stats]).to be_nil
+      end
+    end
   end
 end

--- a/spec/services/portfolio_stats_service_spec.rb
+++ b/spec/services/portfolio_stats_service_spec.rb
@@ -1,0 +1,128 @@
+require 'rails_helper'
+
+RSpec.describe PortfolioStatsService do
+  describe '.call' do
+    let(:user) { create(:user, preferred_currency: "USD") }
+
+    it 'returns nil for an empty portfolio' do
+      expect(described_class.call(user)).to be_nil
+    end
+
+    context 'with a single-currency (USD) portfolio' do
+      before do
+        aapl = create(:stock, symbol: "AAPL", currency: "USD", price: 200.0, dividend: 4.0, sector: "Technology")
+        ko   = create(:stock, symbol: "KO",   currency: "USD", price: 60.0,  dividend: 1.80, sector: "Consumer Staples")
+        create(:holding, user: user, stock: aapl, quantity: 10, average_price: 150.0) # cost 1500, value 2000, inc 40
+        create(:holding, user: user, stock: ko,   quantity: 50, average_price: 50.0)  # cost 2500, value 3000, inc 90
+      end
+
+      it 'computes YoC and current yield per currency' do
+        result = described_class.call(user)
+        # income 130 / cost 4000 = 3.25%; income 130 / value 5000 = 2.6%
+        expect(result[:byCurrency]["USD"][:yoc]).to be_within(0.01).of(3.25)
+        expect(result[:byCurrency]["USD"][:currentYield]).to be_within(0.01).of(2.6)
+      end
+
+      it 'fills displayYoc and displayCurrentYield with the same numbers (identity FX)' do
+        result = described_class.call(user)
+        expect(result[:displayCurrency]).to eq("USD")
+        expect(result[:displayYoc]).to be_within(0.01).of(3.25)
+        expect(result[:displayCurrentYield]).to be_within(0.01).of(2.6)
+      end
+
+      it 'groups sectors by market value (in display currency)' do
+        result = described_class.call(user)
+        sectors = result[:sectors]
+        expect(sectors.size).to eq(2)
+        # Consumer Staples (3000) > Technology (2000)
+        expect(sectors.first[:sector]).to eq("Consumer Staples")
+        expect(sectors.first[:percent]).to eq(60.0)
+        expect(sectors.last[:percent]).to eq(40.0)
+      end
+    end
+
+    context 'with a mixed-currency portfolio and FX' do
+      before do
+        aapl    = create(:stock, symbol: "AAPL",   currency: "USD", price: 200.0, dividend: 4.0)
+        iberdrola = create(:stock, symbol: "IBE.MC", currency: "EUR", price: 14.0,  dividend: 0.5)
+        create(:holding, user: user, stock: aapl,      quantity: 10, average_price: 150.0)
+        create(:holding, user: user, stock: iberdrola, quantity: 100, average_price: 12.0)
+        allow(FxRateService).to receive(:convert) do |amount, from:, to:|
+          if from == to
+            amount
+          elsif from == "EUR" && to == "USD"
+            amount * 1.1
+          end
+        end
+      end
+
+      it 'populates byCurrency with per-currency yields' do
+        result = described_class.call(user)
+        expect(result[:byCurrency].keys).to contain_exactly("USD", "EUR")
+      end
+
+      it 'produces a display-currency aggregate using the FX rate' do
+        result = described_class.call(user)
+        # USD: inc=40, cost=1500, value=2000
+        # EUR converted to USD: inc=50*1.1=55, cost=1200*1.1=1320, value=1400*1.1=1540
+        # display_yoc = (40 + 55) / (1500 + 1320) ≈ 3.37
+        expect(result[:displayYoc]).to be_within(0.05).of(3.37)
+      end
+    end
+
+    context 'when FX conversion fails' do
+      before do
+        aapl    = create(:stock, symbol: "AAPL",   currency: "USD", price: 200.0, dividend: 4.0)
+        iberdrola = create(:stock, symbol: "IBE.MC", currency: "EUR", price: 14.0,  dividend: 0.5)
+        create(:holding, user: user, stock: aapl,      quantity: 10, average_price: 150.0)
+        create(:holding, user: user, stock: iberdrola, quantity: 100, average_price: 12.0)
+        allow(FxRateService).to receive(:convert) do |amount, from:, to:|
+          from == to ? amount : nil
+        end
+      end
+
+      it 'returns nil for displayYoc and displayCurrentYield' do
+        result = described_class.call(user)
+        expect(result[:displayYoc]).to be_nil
+        expect(result[:displayCurrentYield]).to be_nil
+      end
+
+      it 'still populates byCurrency' do
+        result = described_class.call(user)
+        expect(result[:byCurrency].keys).to contain_exactly("USD", "EUR")
+      end
+
+      it 'returns an empty sectors array (no partial render)' do
+        result = described_class.call(user)
+        expect(result[:sectors]).to eq([])
+      end
+    end
+
+    context 'sectors with nil values' do
+      before do
+        with_sector = create(:stock, symbol: "AAPL", currency: "USD", price: 200.0, dividend: 4.0, sector: "Technology")
+        no_sector   = create(:stock, symbol: "XYZ",  currency: "USD", price: 50.0,  dividend: 1.0, sector: nil)
+        create(:holding, user: user, stock: with_sector, quantity: 10, average_price: 150.0) # 2000
+        create(:holding, user: user, stock: no_sector,   quantity: 20, average_price: 40.0)  # 1000
+      end
+
+      it 'buckets nil-sector holdings as Unknown' do
+        result = described_class.call(user)
+        sectors = result[:sectors].map { |s| s[:sector] }
+        expect(sectors).to contain_exactly("Technology", "Unknown")
+      end
+    end
+
+    context 'when no holding has a sector at all' do
+      before do
+        s = create(:stock, symbol: "AAPL", currency: "USD", price: 200.0, dividend: 4.0, sector: nil)
+        create(:holding, user: user, stock: s, quantity: 10, average_price: 150.0)
+      end
+
+      it 'returns an empty sectors array' do
+        result = described_class.call(user)
+        expect(result[:sectors]).to eq([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Five commits in review order:

1. **Bump \`yahoo_finance_client\` to 0.8.0** — picks up \`Stock.get_quote_summary\`.
2. **Persist sector / industry from both providers + AV FX parity** — \`sector\` & \`industry\` columns on \`stocks\`. Yahoo populates via an extra \`quoteSummary\` call (gated by an existence check so v10 isn't hit on every refresh). AV reads from OVERVIEW. Also new \`AlphaVantageFxProvider\` wired to AV's \`CURRENCY_EXCHANGE_RATE\` endpoint so users on the AV stock provider finally get FX conversion.
3. **Portfolio stats card** — new \`PortfolioStatsService\` aggregates YoC, current yield, sector breakdown. Per-currency math + display-currency aggregate via \`FxRateService.convert\`. Frontend renders a pure-CSS stacked-bar — no chart library.
4. **Admin Activity section** — \`activeUsers7d/30d\`, \`holdingChanges7d/30d\`, \`usersTouchingHoldings7d\`, 8-week session-creation trend. Single-table queries, counts only.
5. **Ship pre-aggregated stats in the NATS payload** — Pulse companion PR consumes these to render YoC/current yield + sector breakdown on \`/p/:slug\` without duplicating the math in Elixir.

## Provider parity audit (per your nudge)
| PR | Field | Yahoo | AlphaVantage |
|---|---|---|---|
| #137 phase 1 | \`currency\` | ✓ | ✓ |
| #138/#140 phase 2 | FX rates | ✓ (default) | ✗ → **fixed here** |
| #141 | dividend/eps unit normalize | provider-agnostic | provider-agnostic |
| **This PR** | \`sector\` / \`industry\` | ✓ | ✓ |

## YoC math note
Yield on Cost uses \`Holding.average_price\`, which the user enters themselves (either via the Add-holding form or set to the current price at buy-plan import). So YoC is "yield on the cost basis you told us" — accurate if the operator's input is. A stricter tax-lot ledger would need a Transactions-table extension (out of scope here).

## Test plan
- [x] \`bundle exec rspec\` — 523 examples, 0 failures, 1 pending.
- [x] \`bin/rubocop\` — clean.
- [x] \`npx tsc --noEmit\` — clean.
- [ ] After deploy: \`bin/kamal app exec "bin/rails runner 'RefreshStocksJob.perform_now(force: true)'"\` to backfill sector data.
- [ ] Visit \`/portfolio\` for a held-stock user — confirm stats card renders, sector breakdown shows post-backfill.
- [ ] Visit \`/admin\` — Activity section appears.
- [ ] Companion Pulse PR consumes the new \`stats\` payload field to render YoC/current yield + sectors on \`/p/:slug\` and a community sector breakdown on \`/\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)