### PR TITLE
Drop copy-link button, defer to Pulse's native share

### DIFF
--- a/app/frontend/components/PulseShareButton.tsx
+++ b/app/frontend/components/PulseShareButton.tsx
@@ -1,15 +1,12 @@
-import { useState } from 'react'
-import { Check, Copy, ExternalLink, Activity } from 'lucide-react'
+import { ExternalLink, Activity } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { useProfile } from '../hooks/useProfileQueries'
-import { Button } from '@/components/ui/button'
 import { pulsePortfolioUrl } from '../lib/pulse'
 
 export function PulseShareButton() {
   const { t } = useTranslation()
   const { data: profile, isLoading } = useProfile()
-  const [copied, setCopied] = useState(false)
 
   if (isLoading) return null
 
@@ -26,47 +23,17 @@ export function PulseShareButton() {
     )
   }
 
-  const url = pulsePortfolioUrl(slug)
-
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(url)
-      setCopied(true)
-      setTimeout(() => setCopied(false), 2000)
-    } catch {
-      // Clipboard API can fail outside HTTPS / when permission denied — silently
-      // fall back to the "View on Pulse" link.
-    }
-  }
-
   return (
-    <div className="flex flex-wrap items-center gap-2">
-      <Button
-        type="button"
-        variant="outline"
-        size="sm"
-        onClick={handleCopy}
-        className="border-purple-200 dark:border-purple-800 text-purple-700 dark:text-purple-300 hover:bg-purple-50 dark:hover:bg-purple-950/30"
-      >
-        {copied ? (
-          <>
-            <Check className="size-3.5" /> {t('portfolio.shareLinkCopied')}
-          </>
-        ) : (
-          <>
-            <Copy className="size-3.5" /> {t('portfolio.copyShareLink')}
-          </>
-        )}
-      </Button>
-      <a
-        href={url}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-purple-600 dark:hover:text-purple-400 hover:underline"
-      >
-        {t('portfolio.viewOnPulse')} <ExternalLink className="size-3" />
-      </a>
-    </div>
+    <a
+      href={pulsePortfolioUrl(slug)}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="inline-flex items-center gap-1.5 text-sm text-purple-700 dark:text-purple-300 hover:underline"
+    >
+      <Activity className="size-4" />
+      {t('portfolio.shareOnPulse')}
+      <ExternalLink className="size-3" />
+    </a>
   )
 }
 

--- a/app/frontend/locales/en.ts
+++ b/app/frontend/locales/en.ts
@@ -163,9 +163,7 @@ const en = {
     failedToLoadPortfolio: 'Failed to load portfolio',
     failedToRemoveHolding: 'Failed to remove holding',
     dividendCalendar: 'Dividend Calendar',
-    copyShareLink: 'Copy share link',
-    shareLinkCopied: 'Copied!',
-    viewOnPulse: 'View on Pulse ↗',
+    shareOnPulse: 'Share on Pulse',
     shareOnPulseHint: 'Share your portfolio on Pulse — opt in from Settings',
     stats: {
       title: 'Portfolio stats',

--- a/app/frontend/locales/es.ts
+++ b/app/frontend/locales/es.ts
@@ -163,9 +163,7 @@ const es = {
     failedToLoadPortfolio: 'Error al cargar la cartera',
     failedToRemoveHolding: 'Error al eliminar posici\u00f3n',
     dividendCalendar: 'Calendario de Dividendos',
-    copyShareLink: 'Copiar enlace',
-    shareLinkCopied: '\u00a1Copiado!',
-    viewOnPulse: 'Ver en Pulse \u2197',
+    shareOnPulse: 'Compartir en Pulse',
     shareOnPulseHint: 'Comparte tu cartera en Pulse \u2014 act\u00edvalo en Ajustes',
     stats: {
       title: 'M\u00e9tricas de cartera',


### PR DESCRIPTION
## Summary

Follow-up to #145. The copy-to-clipboard button on PortfolioPage duplicated Pulse's own share surface poorly — Pulse's /p/:slug page already has *Save Image* and a native share sheet with an OG thumbnail. Plain copy-the-text-URL is a worse share.

- Replace the copy button with a single *Share on Pulse ↗* link that sends the user to their public page, where Pulse handles the actual share UX.
- Remove the clipboard logic, Copy/Check icons, and the now-unused `copyShareLink` / `shareLinkCopied` / `viewOnPulse` locale keys.
- Add `portfolio.shareOnPulse` label in en + es.
- Opted-out hint unchanged.

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] Manual (with slug): `/portfolio` header shows one *Share on Pulse ↗* link; click opens `/p/<slug>` in a new tab
- [ ] Manual (no slug): `/portfolio` shows the opt-in hint linking to Settings (unchanged)
- [ ] Manual: switch language to Spanish — *Compartir en Pulse* reads naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)