### PR TITLE
Add pencil affordance to editable stock card values

### DIFF
--- a/app/frontend/components/PortfolioStockCard.tsx
+++ b/app/frontend/components/PortfolioStockCard.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react'
-import { Check, X } from 'lucide-react'
+import { Check, Pencil, X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useInlineEdit } from '../hooks/useInlineEdit'
 import { useUpdateHolding } from '../hooks/useHoldingsQueries'
@@ -141,10 +141,11 @@ export function PortfolioStockCard({ holding, onRemove, isRemoving }: PortfolioS
             ) : (
               <span
                 onClick={startQtyEdit}
-                className="font-semibold text-foreground cursor-pointer hover:text-muted-foreground transition-colors"
+                className="inline-flex items-center gap-1 font-semibold text-foreground cursor-pointer group hover:text-muted-foreground transition-colors"
                 title={t('common.clickToEdit')}
               >
                 {holding.quantity}
+                <Pencil className="size-3 text-muted-foreground/60 group-hover:text-muted-foreground" />
               </span>
             )}
           </div>
@@ -173,10 +174,11 @@ export function PortfolioStockCard({ holding, onRemove, isRemoving }: PortfolioS
             ) : (
               <span
                 onClick={startAvgEdit}
-                className="font-semibold text-foreground cursor-pointer hover:text-muted-foreground transition-colors"
+                className="inline-flex items-center gap-1 font-semibold text-foreground cursor-pointer group hover:text-muted-foreground transition-colors"
                 title={t('common.clickToEdit')}
               >
                 {formatCurrency(holding.averagePrice, holding.stock.currency)}
+                <Pencil className="size-3 text-muted-foreground/60 group-hover:text-muted-foreground" />
               </span>
             )}
           </div>

--- a/app/frontend/components/PortfolioStockRow.tsx
+++ b/app/frontend/components/PortfolioStockRow.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from 'react'
-import { Check, X, ChevronDown } from 'lucide-react'
+import { Check, Pencil, X, ChevronDown } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useInlineEdit } from '../hooks/useInlineEdit'
 import { useUpdateHolding } from '../hooks/useHoldingsQueries'
@@ -131,10 +131,11 @@ export function PortfolioStockRow({ holding, onRemove, isRemoving, showMetrics =
             ) : (
               <span
                 onClick={startQtyEdit}
-                className="text-sm text-foreground cursor-pointer hover:text-muted-foreground transition-colors"
+                className="inline-flex items-center gap-1 text-sm text-foreground cursor-pointer group hover:text-muted-foreground transition-colors"
                 title={t('common.clickToEdit')}
               >
                 {holding.quantity}
+                <Pencil className="size-3 text-muted-foreground/60 group-hover:text-muted-foreground" />
               </span>
             )}
           </div>
@@ -164,10 +165,11 @@ export function PortfolioStockRow({ holding, onRemove, isRemoving, showMetrics =
             ) : (
               <span
                 onClick={startAvgEdit}
-                className="text-sm text-muted-foreground cursor-pointer hover:text-foreground transition-colors"
+                className="inline-flex items-center gap-1 text-sm text-muted-foreground cursor-pointer group hover:text-foreground transition-colors"
                 title={t('common.clickToEdit')}
               >
                 {formatCurrency(holding.averagePrice, holding.stock.currency)}
+                <Pencil className="size-3 text-muted-foreground/60 group-hover:text-foreground" />
               </span>
             )}
           </div>
@@ -255,8 +257,13 @@ export function PortfolioStockRow({ holding, onRemove, isRemoving, showMetrics =
                       </Button>
                     </span>
                   ) : (
-                    <button onClick={startQtyEdit} className="text-foreground font-medium cursor-pointer">
-                      {holding.quantity} ({t('common.clickToEdit')})
+                    <button
+                      onClick={startQtyEdit}
+                      className="inline-flex items-center gap-1 text-foreground font-medium cursor-pointer"
+                      title={t('common.clickToEdit')}
+                    >
+                      {holding.quantity}
+                      <Pencil className="size-3 text-muted-foreground" />
                     </button>
                   )}
                 </div>
@@ -283,8 +290,13 @@ export function PortfolioStockRow({ holding, onRemove, isRemoving, showMetrics =
                       </Button>
                     </span>
                   ) : (
-                    <button onClick={startAvgEdit} className="text-foreground font-medium cursor-pointer">
-                      {formatCurrency(holding.averagePrice, holding.stock.currency)} ({t('common.clickToEdit')})
+                    <button
+                      onClick={startAvgEdit}
+                      className="inline-flex items-center gap-1 text-foreground font-medium cursor-pointer"
+                      title={t('common.clickToEdit')}
+                    >
+                      {formatCurrency(holding.averagePrice, holding.stock.currency)}
+                      <Pencil className="size-3 text-muted-foreground" />
                     </button>
                   )}
                 </div>

--- a/app/frontend/components/RadarStockCard.tsx
+++ b/app/frontend/components/RadarStockCard.tsx
@@ -1,4 +1,4 @@
-import { Check, X } from 'lucide-react'
+import { Check, Pencil, X } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useInlineEdit } from '../hooks/useInlineEdit'
 import { useUpdateTargetPrice } from '../hooks/useRadarQueries'
@@ -116,10 +116,11 @@ export function RadarStockCard({ stock, onRemove, isRemoving }: RadarStockCardPr
             ) : (
               <span
                 onClick={startEdit}
-                className="font-semibold text-foreground cursor-pointer hover:text-muted-foreground transition-colors"
+                className="inline-flex items-center gap-1 font-semibold text-foreground cursor-pointer group hover:text-muted-foreground transition-colors"
                 title={t('common.clickToEdit')}
               >
                 {stock.formattedTargetPrice}
+                <Pencil className="size-3 text-muted-foreground/60 group-hover:text-muted-foreground" />
               </span>
             )}
           </div>

--- a/app/frontend/components/RadarStockRow.tsx
+++ b/app/frontend/components/RadarStockRow.tsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { Check, X, ChevronDown, ArrowDown, ArrowUp, Minus as MinusIcon } from 'lucide-react'
+import { Check, Pencil, X, ChevronDown, ArrowDown, ArrowUp, Minus as MinusIcon } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useInlineEdit } from '../hooks/useInlineEdit'
 import { useUpdateTargetPrice } from '../hooks/useRadarQueries'
@@ -120,10 +120,11 @@ export function RadarStockRow({ stock, onRemove, isRemoving, showMetrics = false
             ) : (
               <span
                 onClick={startEdit}
-                className="text-sm text-muted-foreground cursor-pointer hover:text-foreground transition-colors"
+                className="inline-flex items-center gap-1 text-sm text-muted-foreground cursor-pointer group hover:text-foreground transition-colors"
                 title={t('common.clickToEdit')}
               >
                 {stock.formattedTargetPrice}
+                <Pencil className="size-3 text-muted-foreground/60 group-hover:text-foreground" />
               </span>
             )}
           </div>
@@ -211,9 +212,11 @@ export function RadarStockRow({ stock, onRemove, isRemoving, showMetrics = false
                 ) : (
                   <button
                     onClick={startEdit}
-                    className="text-sm text-foreground font-medium cursor-pointer"
+                    className="inline-flex items-center gap-1 text-sm text-foreground font-medium cursor-pointer"
+                    title={t('common.clickToEdit')}
                   >
-                    {stock.formattedTargetPrice} ({t('common.clickToEdit')})
+                    {stock.formattedTargetPrice}
+                    <Pencil className="size-3 text-muted-foreground" />
                   </button>
                 )}
               </div>


### PR DESCRIPTION
## Summary

Editable values on the radar and portfolio stock cards only signalled \"tap me\" with `cursor-pointer` + a hover-only color shift + a `title` tooltip — none of which work on mobile. Users had no way to discover that quantities, average prices, and target prices were editable.

Add a small muted Pencil icon inline after each editable value, across all four stock surfaces:

- **PortfolioStockCard** — quantity, average price
- **PortfolioStockRow** — desktop quantity, desktop avg, mobile-expanded quantity, mobile-expanded avg
- **RadarStockCard** — target price
- **RadarStockRow** — desktop target, mobile-expanded target

The mobile-expanded views also had a verbose \"(Click to edit)\" parenthetical that's now replaced by the same pencil — visually much cleaner.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vite build` clean
- [ ] Manual desktop: /radar + /portfolio in both card and compact views — pencil visible next to each editable value; clicking either the value or the pencil opens inline edit; pencil darkens on hover
- [ ] Manual mobile (or narrow viewport): values + pencils visible; tapping a row to expand shows the same affordance in the expanded panel; no more \"(Click to edit)\" text
- [ ] Spanish locale renders the same (no copy changes here — pencil is language-neutral)

🤖 Generated with [Claude Code](https://claude.com/claude-code)