### PR TITLE
Stop substituting payment date for missing ex-dividend date

### DIFF
--- a/app/services/financial_data_providers/yahoo_finance_provider.rb
+++ b/app/services/financial_data_providers/yahoo_finance_provider.rb
@@ -52,7 +52,11 @@ module FinancialDataProviders
         ma_200: data[:ma200],
         fifty_two_week_high: data[:fifty_two_week_high],
         fifty_two_week_low: data[:fifty_two_week_low],
-        ex_dividend_date: data[:ex_dividend_date] || data[:dividend_date]
+        # IMPORTANT: don't fall back to `dividend_date` — that's Yahoo's
+        # *payment* date, not the ex-dividend date. They differ by ~2 weeks,
+        # so substituting payment date as ex-div produced wrong info in the
+        # UI and in AI-generated social drafts. Leave nil when missing.
+        ex_dividend_date: data[:ex_dividend_date]
       }
     end
 

--- a/spec/services/financial_data_providers/yahoo_finance_provider_spec.rb
+++ b/spec/services/financial_data_providers/yahoo_finance_provider_spec.rb
@@ -90,6 +90,18 @@ RSpec.describe FinancialDataProviders::YahooFinanceProvider, type: :model do
       expect(result[:ex_dividend_date]).to eq(Date.new(2024, 3, 14))
     end
 
+    # Regression: `dividend_date` is Yahoo's *payment* date, not the ex-div
+    # date. We must NOT fall back to it — they're typically ~2 weeks apart.
+    it 'does not substitute dividend_date (payment date) for a missing ex_dividend_date' do
+      data = {
+        symbol: 'TXN', price: 150.00, dividend: 1.36,
+        ex_dividend_date: nil,
+        dividend_date: Date.new(2026, 5, 19) # payment date — must not leak through
+      }
+      result = provider.send(:normalize_yahoo_data, data)
+      expect(result[:ex_dividend_date]).to be_nil
+    end
+
     it 'passes through currency from the gem' do
       data = { symbol: 'IBE.MC', price: 14.5, currency: 'EUR' }
       result = provider.send(:normalize_yahoo_data, data)


### PR DESCRIPTION
## Summary

You noticed an AI social draft saying TXN's ex-dividend date was May 19, but the real ex-div was May 5 — May 19 is the *payment* date. The bug is in YahooFinanceProvider.

\`\`\`ruby
# Before
ex_dividend_date: data[:ex_dividend_date] || data[:dividend_date]
\`\`\`

The gem returns these as two separate fields straight from Yahoo's quote response:
- \`ex_dividend_date\` ← \`exDividendDate\` (when you must hold by)
- \`dividend_date\` ← \`dividendDate\` (when you actually get paid)

They typically differ by ~2 weeks. The fallback substituted payment date as ex-div whenever Yahoo's quote response was missing \`exDividendDate\`, which silently wrong-footed the UI and the AI drafts.

Fix: drop the fallback. When Yahoo doesn't return \`ex_dividend_date\`, leave it nil — the decorator and templates already handle nil gracefully (badge just hides, draft templates short-circuit via \`any_upcoming_ex_dividend?\`).

## Test plan

- [x] \`bundle exec rspec spec/services/financial_data_providers/yahoo_finance_provider_spec.rb\` — 16 examples, 0 failures (includes new regression spec asserting payment date never leaks through)
- [ ] After deploy: \`bin/kamal app exec \"bin/rails runner 'RefreshStocksJob.perform_now(force: true)'\"\` to clear any stocks already storing payment date as ex-div
- [ ] Manual: verify TXN's ex-div badge reads May 5 (not May 19) after refresh
- [ ] Manual: generate a new \"upcoming ex-dividend\" social draft — dates should match the actual ex-div dates

🤖 Generated with [Claude Code](https://claude.com/claude-code)