### PR TITLE
Explicitly unlink uploaded CSV after parsing

### DIFF
--- a/app/controllers/api/v1/dividends_controller.rb
+++ b/app/controllers/api/v1/dividends_controller.rb
@@ -52,12 +52,22 @@ module Api
         file = params[:file]
         return render_error("Missing file", status: :unprocessable_entity) if file.blank?
 
-        parsed = DividendImporters::Ibkr.parse(file.to_io)
-        preview = DividendImports::Preview.call(parsed: parsed, user: Current.user)
-        render_success(preview)
-      rescue StandardError => e
-        Rails.logger.error "Dividend import preview failed: #{e.class}: #{e.message}"
-        render_error("Could not parse the file: #{e.message}", status: :unprocessable_entity)
+        tempfile = file.tempfile
+        begin
+          parsed = DividendImporters::Ibkr.parse(tempfile)
+          preview = DividendImports::Preview.call(parsed: parsed, user: Current.user)
+          render_success(preview)
+        rescue StandardError => e
+          Rails.logger.error "Dividend import preview failed: #{e.class}: #{e.message}"
+          render_error("Could not parse the file: #{e.message}", status: :unprocessable_entity)
+        ensure
+          # Belt-and-suspenders: Rack/Tempfile's finalizer would unlink this
+          # eventually, but we delete it the moment parsing finishes so the
+          # CSV — which contains the user's positions and amounts — never
+          # lingers on the filesystem.
+          tempfile&.close
+          tempfile&.unlink if tempfile.respond_to?(:unlink)
+        end
       end
 
       # POST /api/v1/dividends/import_apply   body: { rows: [...], mapping: { ticker => stock_id } }

--- a/app/frontend/locales/en.ts
+++ b/app/frontend/locales/en.ts
@@ -209,7 +209,7 @@ const en = {
     importIbkrPathLabel: 'Where to find this in IBKR:',
     importIbkrPathEn: 'EN: Performance & Reports → Statements → Activity',
     importIbkrPathEs: 'ES: Rendimientos e informes → Extractos → Informe de actividad',
-    importPrivacyHint: 'Before uploading you can safely strip the header rows (name, account, address) — only the Dividends and Withholding Tax sections are parsed.',
+    importPrivacyHint: 'Only the Dividends and Withholding Tax sections are parsed — you can safely strip the header rows (name, account, address) first. The uploaded file is deleted from the server as soon as parsing finishes.',
     importParsing: 'Parsing…',
     importMatched: 'Auto-matched',
     importUnmatched: 'Need your input',

--- a/app/frontend/locales/es.ts
+++ b/app/frontend/locales/es.ts
@@ -209,7 +209,7 @@ const es = {
     importIbkrPathLabel: 'Dónde encontrarlo en IBKR:',
     importIbkrPathEn: 'EN: Performance & Reports → Statements → Activity',
     importIbkrPathEs: 'ES: Rendimientos e informes → Extractos → Informe de actividad',
-    importPrivacyHint: 'Antes de subir, puedes eliminar sin problema las filas de cabecera (nombre, cuenta, dirección) — sólo se procesan las secciones de Dividendos y Retención de impuestos.',
+    importPrivacyHint: 'Sólo se procesan las secciones de Dividendos y Retención de impuestos — puedes eliminar primero las filas de cabecera (nombre, cuenta, dirección) sin problema. El archivo subido se elimina del servidor en cuanto termina el procesado.',
     importParsing: 'Procesando…',
     importMatched: 'Auto-emparejados',
     importUnmatched: 'Necesitan tu input',


### PR DESCRIPTION
## Summary

You flagged this on the dividend import PR: were the uploaded CSVs being deleted?

Technically yes — Rack creates the upload as a \`Tempfile\` and Ruby's GC finalizer unlinks it when the object is collected. But that's non-deterministic; the file can linger on disk for a while after the response.

Fix: wrap the parse in an \`ensure\` block that \`close\` + \`unlink\` the tempfile the moment parsing finishes, so the CSV (which has the user's positions, amounts, and tax data) never outlives the request.

Also updated the privacy hint in the import dialog to call this out explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)