### PR TITLE
Hide dividend charts when there's no dividend history

### DIFF
--- a/app/frontend/pages/DividendsPage.tsx
+++ b/app/frontend/pages/DividendsPage.tsx
@@ -80,7 +80,7 @@ export function DividendsPage() {
           </div>
         </CardHeader>
         <CardContent>
-          {(Object.keys(totalsByCurrency).length > 0 || chartData) && (
+          {dividends && dividends.length > 0 && (
             <div className="grid grid-cols-1 lg:grid-cols-3 gap-3 mb-6">
               {Object.keys(totalsByCurrency).length > 0 && (
                 <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 gap-3">


### PR DESCRIPTION
## Summary

You spotted that the 12-month chart shows up even when the user has zero recorded dividends.

Root cause: the chart row was gated on \"has any chart_data fetched\". But the backend always returns a payload, including **projected** bars derived from current Holdings × known payment schedules. So a user with portfolio holdings but no imported dividends saw a half-empty bar chart with only future projection bars on the right and nothing on the left — confusing.

Fix: gate the entire row (totals + charts) on \`dividends.length > 0\`. When the user has no dividend history, the existing empty state owns the page until there's real data to draw against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)