### PR TITLE
Smart target-price anchors + allow clearing the target

### DIFF
--- a/app/controllers/api/v1/radars_controller.rb
+++ b/app/controllers/api/v1/radars_controller.rb
@@ -10,6 +10,10 @@ module Api
       # Returns the user's radar with all stocks and their target prices
       def show
         stocks = @radar.sorted_stocks || []
+        @community_targets = Stocks::CommunityTargetPrice.call(
+          stock_ids: stocks.map(&:id),
+          exclude_radar_id: @radar.id
+        )
         render_success({
           id: @radar.id,
           stocks: stocks.map { |s| serialize_radar_stock(s) }
@@ -90,6 +94,7 @@ module Api
           aboveTarget: decorated.above_target?,
           belowTarget: decorated.below_target?,
           atTarget: decorated.at_target?,
+          targetAnchors: target_anchors(stock),
           **serialize_stock_metrics(stock, decorated)
         }
       end
@@ -114,6 +119,24 @@ module Api
           atTarget: decorated.at_target?,
           **serialize_stock_metrics(stock, decorated)
         }
+      end
+
+      # Anchor values the user can apply with one click as their target price.
+      # Community is suppressed below the cohort threshold by the service.
+      # 52-week midpoint requires both high and low to be present.
+      def target_anchors(stock)
+        community = @community_targets&.dig(stock.id) || { count: 0, average: nil }
+        {
+          community: { value: community[:average], count: community[:count] },
+          fiftyTwoWeekMidpoint: midpoint_or_nil(stock),
+          ma200: stock.ma_200&.to_f,
+          ma50: stock.ma_50&.to_f
+        }
+      end
+
+      def midpoint_or_nil(stock)
+        return nil if stock.fifty_two_week_high.blank? || stock.fifty_two_week_low.blank?
+        ((stock.fifty_two_week_high.to_f + stock.fifty_two_week_low.to_f) / 2.0).round(2)
       end
 
       # Serialize stock data for AI analysis (compact, numeric-only)

--- a/app/frontend/components/RadarStockCard.tsx
+++ b/app/frontend/components/RadarStockCard.tsx
@@ -1,4 +1,5 @@
 import { Check, Pencil, X } from 'lucide-react'
+import { TargetPriceAnchorsMenu } from './TargetPriceAnchorsMenu'
 import { useTranslation } from 'react-i18next'
 import { useInlineEdit } from '../hooks/useInlineEdit'
 import { useUpdateTargetPrice } from '../hooks/useRadarQueries'
@@ -39,8 +40,15 @@ export function RadarStockCard({ stock, onRemove, isRemoving }: RadarStockCardPr
   } = useInlineEdit({
     initialValue: stock.targetPrice?.toString() ?? '',
     onSave: async (newValue) => {
-      const price = newValue === '' ? 0 : parseFloat(newValue)
-      await updateTargetPrice.mutateAsync({ stockId: stock.id, price })
+      const trimmed = newValue.trim()
+      const price = trimmed === '' ? null : parseFloat(trimmed)
+      try {
+        await updateTargetPrice.mutateAsync({ stockId: stock.id, price })
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : ''
+        if (/greater than 0/i.test(msg)) throw new Error(t('radar.errors.targetPriceMustBePositive'))
+        throw err
+      }
     },
   })
 
@@ -105,6 +113,7 @@ export function RadarStockCard({ stock, onRemove, isRemoving }: RadarStockCardPr
                   disabled={isSaving}
                   className="w-20 h-7 px-2 text-sm"
                   placeholder="0.00"
+                  title={t('radar.clearTargetHint')}
                 />
                 <Button size="icon-xs" onClick={save} disabled={isSaving}>
                   {isSaving ? '...' : <Check className="size-3" />}
@@ -114,13 +123,20 @@ export function RadarStockCard({ stock, onRemove, isRemoving }: RadarStockCardPr
                 </Button>
               </span>
             ) : (
-              <span
-                onClick={startEdit}
-                className="inline-flex items-center gap-1 font-semibold text-foreground cursor-pointer group hover:text-muted-foreground transition-colors"
-                title={t('common.clickToEdit')}
-              >
-                {stock.formattedTargetPrice}
-                <Pencil className="size-3 text-muted-foreground/60 group-hover:text-muted-foreground" />
+              <span className="inline-flex items-center gap-1">
+                <span
+                  onClick={startEdit}
+                  className="inline-flex items-center gap-1 font-semibold text-foreground cursor-pointer group hover:text-muted-foreground transition-colors"
+                  title={t('common.clickToEdit')}
+                >
+                  {stock.formattedTargetPrice}
+                  <Pencil className="size-3 text-muted-foreground/60 group-hover:text-muted-foreground" />
+                </span>
+                <TargetPriceAnchorsMenu
+                  stockId={stock.id}
+                  currency={stock.currency}
+                  anchors={stock.targetAnchors}
+                />
               </span>
             )}
           </div>

--- a/app/frontend/components/RadarStockRow.tsx
+++ b/app/frontend/components/RadarStockRow.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { Check, Pencil, X, ChevronDown, ArrowDown, ArrowUp, Minus as MinusIcon } from 'lucide-react'
+import { TargetPriceAnchorsMenu } from './TargetPriceAnchorsMenu'
 import { useTranslation } from 'react-i18next'
 import { useInlineEdit } from '../hooks/useInlineEdit'
 import { useUpdateTargetPrice } from '../hooks/useRadarQueries'
@@ -41,8 +42,15 @@ export function RadarStockRow({ stock, onRemove, isRemoving, showMetrics = false
   } = useInlineEdit({
     initialValue: stock.targetPrice?.toString() ?? '',
     onSave: async (newValue) => {
-      const price = newValue === '' ? 0 : parseFloat(newValue)
-      await updateTargetPrice.mutateAsync({ stockId: stock.id, price })
+      const trimmed = newValue.trim()
+      const price = trimmed === '' ? null : parseFloat(trimmed)
+      try {
+        await updateTargetPrice.mutateAsync({ stockId: stock.id, price })
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : ''
+        if (/greater than 0/i.test(msg)) throw new Error(t('radar.errors.targetPriceMustBePositive'))
+        throw err
+      }
     },
   })
 
@@ -109,6 +117,7 @@ export function RadarStockRow({ stock, onRemove, isRemoving, showMetrics = false
                   disabled={isSaving}
                   className="w-16 h-7 px-2 text-sm"
                   placeholder="0.00"
+                  title={t('radar.clearTargetHint')}
                 />
                 <Button size="icon-xs" onClick={save} disabled={isSaving}>
                   {isSaving ? '...' : <Check className="size-3" />}
@@ -118,13 +127,20 @@ export function RadarStockRow({ stock, onRemove, isRemoving, showMetrics = false
                 </Button>
               </span>
             ) : (
-              <span
-                onClick={startEdit}
-                className="inline-flex items-center gap-1 text-sm text-muted-foreground cursor-pointer group hover:text-foreground transition-colors"
-                title={t('common.clickToEdit')}
-              >
-                {stock.formattedTargetPrice}
-                <Pencil className="size-3 text-muted-foreground/60 group-hover:text-foreground" />
+              <span className="inline-flex items-center gap-1">
+                <span
+                  onClick={startEdit}
+                  className="inline-flex items-center gap-1 text-sm text-muted-foreground cursor-pointer group hover:text-foreground transition-colors"
+                  title={t('common.clickToEdit')}
+                >
+                  {stock.formattedTargetPrice}
+                  <Pencil className="size-3 text-muted-foreground/60 group-hover:text-foreground" />
+                </span>
+                <TargetPriceAnchorsMenu
+                  stockId={stock.id}
+                  currency={stock.currency}
+                  anchors={stock.targetAnchors}
+                />
               </span>
             )}
           </div>
@@ -201,6 +217,7 @@ export function RadarStockRow({ stock, onRemove, isRemoving, showMetrics = false
                       disabled={isSaving}
                       className="w-20 h-7 px-2 text-sm"
                       placeholder="0.00"
+                      title={t('radar.clearTargetHint')}
                     />
                     <Button size="icon-xs" onClick={save} disabled={isSaving}>
                       {isSaving ? '...' : <Check className="size-3" />}
@@ -210,14 +227,21 @@ export function RadarStockRow({ stock, onRemove, isRemoving, showMetrics = false
                     </Button>
                   </span>
                 ) : (
-                  <button
-                    onClick={startEdit}
-                    className="inline-flex items-center gap-1 text-sm text-foreground font-medium cursor-pointer"
-                    title={t('common.clickToEdit')}
-                  >
-                    {stock.formattedTargetPrice}
-                    <Pencil className="size-3 text-muted-foreground" />
-                  </button>
+                  <span className="inline-flex items-center gap-1">
+                    <button
+                      onClick={startEdit}
+                      className="inline-flex items-center gap-1 text-sm text-foreground font-medium cursor-pointer"
+                      title={t('common.clickToEdit')}
+                    >
+                      {stock.formattedTargetPrice}
+                      <Pencil className="size-3 text-muted-foreground" />
+                    </button>
+                    <TargetPriceAnchorsMenu
+                      stockId={stock.id}
+                      currency={stock.currency}
+                      anchors={stock.targetAnchors}
+                    />
+                  </span>
                 )}
               </div>
 

--- a/app/frontend/components/TargetPriceAnchorsMenu.tsx
+++ b/app/frontend/components/TargetPriceAnchorsMenu.tsx
@@ -1,0 +1,143 @@
+import { useState } from 'react'
+import { Wand2, Users, TrendingUp, BarChart3, Activity, Check } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import { formatCurrency } from '../lib/currency'
+import { useUpdateTargetPrice } from '../hooks/useRadarQueries'
+import type { TargetAnchors } from '../types'
+
+const COMMUNITY_MIN_COHORT = 3
+
+interface Props {
+  stockId: number
+  currency: string
+  anchors: TargetAnchors
+}
+
+// Dropdown of "suggest a target" anchors: community average, 52-week
+// midpoint, 200-day MA, 50-day MA. Each entry shows its computed value.
+// Click to apply directly (no edit-then-confirm). Rows with no value are
+// rendered disabled with a short reason in the secondary line.
+export function TargetPriceAnchorsMenu({ stockId, currency, anchors }: Props) {
+  const { t } = useTranslation()
+  const update = useUpdateTargetPrice()
+  const [open, setOpen] = useState(false)
+
+  const rows = [
+    {
+      key: 'community',
+      icon: Users,
+      label: t('radar.anchors.community'),
+      value: anchors.community.value,
+      secondary: anchors.community.value != null
+        ? t('radar.anchors.communityCount', { count: anchors.community.count })
+        : anchors.community.count > 0
+          ? t('radar.anchors.communityBelow', { threshold: COMMUNITY_MIN_COHORT, count: anchors.community.count })
+          : t('radar.anchors.unavailable'),
+    },
+    {
+      key: 'fiftyTwoWeekMidpoint',
+      icon: TrendingUp,
+      label: t('radar.anchors.fiftyTwoWeekMidpoint'),
+      value: anchors.fiftyTwoWeekMidpoint,
+      secondary: anchors.fiftyTwoWeekMidpoint == null ? t('radar.anchors.unavailable') : null,
+    },
+    {
+      key: 'ma200',
+      icon: BarChart3,
+      label: t('radar.anchors.ma200'),
+      value: anchors.ma200,
+      secondary: anchors.ma200 == null ? t('radar.anchors.unavailable') : null,
+    },
+    {
+      key: 'ma50',
+      icon: Activity,
+      label: t('radar.anchors.ma50'),
+      value: anchors.ma50,
+      secondary: anchors.ma50 == null ? t('radar.anchors.unavailable') : null,
+    },
+  ] as const
+
+  const enabledCount = rows.filter((r) => r.value != null).length
+  const triggerDisabled = enabledCount === 0
+
+  const handlePick = (price: number) => {
+    update.mutate({ stockId, price })
+    setOpen(false)
+  }
+
+  return (
+    <TooltipProvider>
+      <DropdownMenu open={open} onOpenChange={setOpen}>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                disabled={triggerDisabled}
+                onClick={(e) => e.stopPropagation()}
+                className={cn(
+                  'inline-flex items-center justify-center rounded-sm p-0.5 transition-colors',
+                  triggerDisabled
+                    ? 'text-muted-foreground/30 cursor-not-allowed'
+                    : 'text-muted-foreground/60 hover:text-foreground cursor-pointer'
+                )}
+                aria-label={t('radar.suggestTarget')}
+              >
+                <Wand2 className="size-3" />
+              </button>
+            </DropdownMenuTrigger>
+          </TooltipTrigger>
+          <TooltipContent>
+            <p className="text-xs">{triggerDisabled ? t('radar.anchors.unavailable') : t('radar.suggestTarget')}</p>
+          </TooltipContent>
+        </Tooltip>
+
+        <DropdownMenuContent
+          align="start"
+          className="w-72"
+          // Stop the click from bubbling up and re-opening the inline editor.
+          onClick={(e) => e.stopPropagation()}
+        >
+          <DropdownMenuLabel>{t('radar.suggestTarget')}</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          {rows.map((row) => {
+            const Icon = row.icon
+            const disabled = row.value == null
+            return (
+              <DropdownMenuItem
+                key={row.key}
+                disabled={disabled}
+                onClick={() => row.value != null && handlePick(row.value)}
+                className="flex items-start gap-2"
+              >
+                <Icon className="size-3.5 mt-0.5 shrink-0 text-muted-foreground" />
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-baseline justify-between gap-2">
+                    <span className="text-sm">{row.label}</span>
+                    <span className="text-sm font-mono tabular-nums">
+                      {row.value != null ? formatCurrency(row.value, currency) : '—'}
+                    </span>
+                  </div>
+                  {row.secondary && (
+                    <p className="text-[11px] text-muted-foreground mt-0.5">{row.secondary}</p>
+                  )}
+                </div>
+                {!disabled && <Check className="size-3 opacity-0 mt-1 shrink-0" />}
+              </DropdownMenuItem>
+            )
+          })}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </TooltipProvider>
+  )
+}

--- a/app/frontend/hooks/useRadarQueries.ts
+++ b/app/frontend/hooks/useRadarQueries.ts
@@ -90,7 +90,7 @@ export function useUpdateTargetPrice() {
   const queryClient = useQueryClient()
 
   return useMutation({
-    mutationFn: ({ stockId, price }: { stockId: number; price: number }) =>
+    mutationFn: ({ stockId, price }: { stockId: number; price: number | null }) =>
       radarApi.updateTargetPrice(stockId, price),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['radar'] })

--- a/app/frontend/locales/en.ts
+++ b/app/frontend/locales/en.ts
@@ -145,6 +145,20 @@ const en = {
     switchToCardView: 'Switch to card view',
     switchToCompactView: 'Switch to compact view',
     addToCart: 'Add to Cart',
+    suggestTarget: 'Suggest a target',
+    clearTargetHint: 'Empty the field to clear the target',
+    errors: {
+      targetPriceMustBePositive: 'Target price must be greater than 0 (leave empty to clear it)',
+    },
+    anchors: {
+      community: 'Community average',
+      communityCount: 'across {{count}} users',
+      communityBelow: 'Need ≥ {{threshold}} community targets · currently {{count}}',
+      fiftyTwoWeekMidpoint: '52-week midpoint',
+      ma200: '200-day MA',
+      ma50: '50-day MA',
+      unavailable: 'Not available yet',
+    },
   },
 
   // Portfolio Page

--- a/app/frontend/locales/es.ts
+++ b/app/frontend/locales/es.ts
@@ -145,6 +145,20 @@ const es = {
     switchToCardView: 'Cambiar a vista de tarjetas',
     switchToCompactView: 'Cambiar a vista compacta',
     addToCart: 'A\u00f1adir al Carrito',
+    suggestTarget: 'Sugerir un objetivo',
+    clearTargetHint: 'Deja el campo vacío para borrar el objetivo',
+    errors: {
+      targetPriceMustBePositive: 'El precio objetivo debe ser mayor que 0 (déjalo vacío para borrarlo)',
+    },
+    anchors: {
+      community: 'Promedio de la comunidad',
+      communityCount: 'en {{count}} usuarios',
+      communityBelow: 'Se necesitan \u2265 {{threshold}} objetivos \u00b7 actualmente {{count}}',
+      fiftyTwoWeekMidpoint: 'Punto medio 52 semanas',
+      ma200: 'Media m\u00f3vil 200 d\u00edas',
+      ma50: 'Media m\u00f3vil 50 d\u00edas',
+      unavailable: 'A\u00fan no disponible',
+    },
   },
 
   // Portfolio Page

--- a/app/frontend/types/index.ts
+++ b/app/frontend/types/index.ts
@@ -82,6 +82,13 @@ export interface StockSearchResult {
  * `extends Stock` means RadarStock has ALL Stock properties
  * plus the additional ones defined here
  */
+export interface TargetAnchors {
+  community: { value: number | null; count: number }
+  fiftyTwoWeekMidpoint: number | null
+  ma200: number | null
+  ma50: number | null
+}
+
 export interface RadarStock extends Stock {
   targetPrice: number | null
   formattedTargetPrice: string
@@ -90,6 +97,7 @@ export interface RadarStock extends Stock {
   aboveTarget: boolean
   belowTarget: boolean
   atTarget: boolean
+  targetAnchors: TargetAnchors
 }
 
 /**

--- a/app/services/stocks/community_target_price.rb
+++ b/app/services/stocks/community_target_price.rb
@@ -1,0 +1,29 @@
+module Stocks
+  # Aggregates the *other* users' target prices for a set of stocks.
+  #
+  # Returns `{ stock_id => { count: Integer, average: Float|nil } }`.
+  # `average` is suppressed (nil) below MIN_COHORT so we don't leak any
+  # individual user's target and so the value reflects a meaningful group.
+  # The requesting radar is always excluded from both count and average.
+  class CommunityTargetPrice
+    MIN_COHORT = 3
+
+    def self.call(stock_ids:, exclude_radar_id:)
+      return {} if stock_ids.blank?
+
+      rows = RadarStock
+        .where(stock_id: stock_ids)
+        .where.not(target_price: nil)
+        .where.not(radar_id: exclude_radar_id)
+        .group(:stock_id)
+        .pluck(:stock_id, Arel.sql("COUNT(*)"), Arel.sql("AVG(target_price)"))
+
+      rows.each_with_object({}) do |(stock_id, count, avg), h|
+        h[stock_id] = {
+          count: count.to_i,
+          average: count.to_i >= MIN_COHORT ? avg.to_f.round(2) : nil
+        }
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/radars_spec.rb
+++ b/spec/requests/api/v1/radars_spec.rb
@@ -90,6 +90,57 @@ RSpec.describe "Api::V1::Radars", type: :request do
           expect(stock_data["dividendScoreLabel"]).to be_a(String)
         end
       end
+
+      context "targetAnchors" do
+        let!(:radar) { create(:radar, user: user) }
+        let!(:anchored_stock) do
+          create(:stock,
+            symbol: "ANCH", name: "Anchor Co.", price: 100.0,
+            ma_50: 95.0, ma_200: 90.0,
+            fifty_two_week_high: 120.0, fifty_two_week_low: 80.0)
+        end
+        let!(:radar_stock) { RadarStock.create!(radar: radar, stock: anchored_stock, target_price: 100) }
+
+        it "exposes the MA + 52-week midpoint anchors" do
+          get "/api/v1/radar"
+          stock_data = JSON.parse(response.body)["data"]["stocks"].first
+
+          expect(stock_data["targetAnchors"]).to include(
+            "fiftyTwoWeekMidpoint" => 100.0,
+            "ma200" => 90.0,
+            "ma50" => 95.0
+          )
+        end
+
+        it "leaves community.average nil when fewer than 3 other users have a target" do
+          get "/api/v1/radar"
+          community = JSON.parse(response.body)["data"]["stocks"].first["targetAnchors"]["community"]
+
+          expect(community).to eq("value" => nil, "count" => 0)
+        end
+
+        it "surfaces community.average once the threshold is met" do
+          3.times do |i|
+            other = create(:user)
+            other_radar = other.radar || create(:radar, user: other)
+            RadarStock.create!(radar: other_radar, stock: anchored_stock, target_price: 150 + i)
+          end
+
+          get "/api/v1/radar"
+          community = JSON.parse(response.body)["data"]["stocks"].first["targetAnchors"]["community"]
+
+          expect(community["count"]).to eq(3)
+          expect(community["value"]).to eq(151.0)
+        end
+
+        it "leaves fiftyTwoWeekMidpoint nil when either bound is missing" do
+          anchored_stock.update!(fifty_two_week_high: nil)
+          get "/api/v1/radar"
+          stock_data = JSON.parse(response.body)["data"]["stocks"].first
+
+          expect(stock_data["targetAnchors"]["fiftyTwoWeekMidpoint"]).to be_nil
+        end
+      end
     end
   end
 

--- a/spec/services/stocks/community_target_price_spec.rb
+++ b/spec/services/stocks/community_target_price_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+RSpec.describe Stocks::CommunityTargetPrice do
+  let(:stock) { create(:stock, symbol: "AAPL") }
+  let(:requesting_user) { create(:user) }
+  let(:requesting_radar) { create(:radar, user: requesting_user) }
+
+  describe ".call" do
+    it "returns an empty hash for an empty stock_ids list" do
+      expect(described_class.call(stock_ids: [], exclude_radar_id: requesting_radar.id)).to eq({})
+    end
+
+    it "excludes the requesting radar from count and average" do
+      RadarStock.create!(radar: requesting_radar, stock: stock, target_price: 100)
+      # 3 other users so the cohort threshold is met
+      3.times do |i|
+        other = create(:user)
+        other_radar = other.radar || create(:radar, user: other)
+        RadarStock.create!(radar: other_radar, stock: stock, target_price: 150 + (i * 10))
+      end
+
+      result = described_class.call(stock_ids: [ stock.id ], exclude_radar_id: requesting_radar.id)
+      expect(result[stock.id][:count]).to eq(3)
+      # avg of 150, 160, 170 = 160.0
+      expect(result[stock.id][:average]).to eq(160.0)
+    end
+
+    it "suppresses the average when count is below MIN_COHORT" do
+      2.times do |i|
+        other = create(:user)
+        other_radar = other.radar || create(:radar, user: other)
+        RadarStock.create!(radar: other_radar, stock: stock, target_price: 200 + i)
+      end
+
+      result = described_class.call(stock_ids: [ stock.id ], exclude_radar_id: requesting_radar.id)
+      expect(result[stock.id][:count]).to eq(2)
+      expect(result[stock.id][:average]).to be_nil
+    end
+
+    it "ignores radar_stocks with a nil target_price" do
+      3.times do
+        other = create(:user)
+        other_radar = other.radar || create(:radar, user: other)
+        RadarStock.create!(radar: other_radar, stock: stock, target_price: nil)
+      end
+
+      result = described_class.call(stock_ids: [ stock.id ], exclude_radar_id: requesting_radar.id)
+      # All three rows had nil target_price → no aggregate row for this stock
+      expect(result[stock.id]).to be_nil
+    end
+
+    it "rounds the average to two decimal places" do
+      [ 100.333, 100.334, 100.335 ].each do |price|
+        other = create(:user)
+        other_radar = other.radar || create(:radar, user: other)
+        RadarStock.create!(radar: other_radar, stock: stock, target_price: price)
+      end
+
+      result = described_class.call(stock_ids: [ stock.id ], exclude_radar_id: requesting_radar.id)
+      expect(result[stock.id][:average]).to eq(100.33) # rounded half-to-even / banker's, but 100.334 rounds to 100.33
+    end
+
+    it "handles multiple stocks in a single query" do
+      other_stock = create(:stock, symbol: "MSFT")
+      3.times do |i|
+        other = create(:user)
+        other_radar = other.radar || create(:radar, user: other)
+        RadarStock.create!(radar: other_radar, stock: stock, target_price: 100)
+        RadarStock.create!(radar: other_radar, stock: other_stock, target_price: 300 + i)
+      end
+
+      result = described_class.call(stock_ids: [ stock.id, other_stock.id ], exclude_radar_id: requesting_radar.id)
+      expect(result.keys).to contain_exactly(stock.id, other_stock.id)
+      expect(result[stock.id][:average]).to eq(100.0)
+      expect(result[other_stock.id][:average]).to eq(301.0)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Two related changes on the radar's target price:

### 1. Smart target-price anchors

A new \"suggest a target\" wand button next to the existing pencil opens a dropdown of four anchor values the user can apply with one click:

- **Community average** — mean \`target_price\` across other users on the same stock. Suppressed below a cohort of **3** to dampen single-opinion noise and avoid leaking individual user targets.
- **52-week midpoint** — \`(high + low) / 2\`
- **200-day moving average**
- **50-day moving average**

Anchors with no data render disabled with a short reason; the trigger button itself disables when none have data.

### 2. Allow clearing the target

The inline edit's \`onSave\` was coercing empty input to \`0\`, which the model's \`greater_than: 0\` validation then rejected — so there was no way to *remove* a target once set. Both handlers now send \`null\` for empty input. Backend already treats nil as \"no target\" via \`presence\` in \`StockRadarService\`. The common \`greater than 0\` validation error is also now translated (en + es), with a hint to leave the field empty to clear.

## Test plan

- [x] \`bundle exec rspec\` — 559 examples, 0 failures (+10 new: 6 service + 4 controller)
- [x] \`npx tsc --noEmit\` clean
- [x] \`npx vite build\` clean
- [ ] Manual: visit \`/radar\`, click the wand on any stock — dropdown shows four rows with values
- [ ] Manual: with 3 seeded users having targets on AAPL, community row is enabled and applies the average; with <3, row is disabled showing \"Need ≥ 3 community targets · currently N\"
- [ ] Manual: click a stock's existing target → clear the value → press Enter → target is removed (display reverts to \"No target set\")
- [ ] Manual: type a negative number → translated error appears with the \"leave empty to clear\" hint
- [ ] Manual: switch to Spanish — anchor labels + clear hint read naturally

## Out of scope

- Per-anchor weighting / blended suggestion — user picks one.
- Pulse / NATS broadcast of RadarStock data.
- Historical trend of community targets.
- A bulk \"apply community avg to all stocks\" action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)