### PR TITLE
Make import dropzone label format-agnostic

### DIFF
--- a/app/frontend/locales/en.ts
+++ b/app/frontend/locales/en.ts
@@ -221,7 +221,7 @@ const en = {
     deleteConfirm: 'Permanently remove {{symbol}} on {{date}}. Imported dividends are protected and must be re-imported to remove.',
     importTitle: 'Import dividends',
     importDescription: 'Upload an IBKR Activity Statement (CSV) or a MyInvestor operations export (XLS). The broker is auto-detected. Re-importing is safe — existing rows are updated, manual entries are never touched.',
-    importPickFile: 'Pick a CSV file',
+    importPickFile: 'Pick a file (CSV or XLS)',
     importHint: 'IBKR Activity Statement (CSV) or MyInvestor operations export (XLS).',
     importIbkrPathLabel: 'Where to find this in IBKR:',
     importIbkrPathEn: 'EN: Performance & Reports → Statements → Activity',

--- a/app/frontend/locales/es.ts
+++ b/app/frontend/locales/es.ts
@@ -221,7 +221,7 @@ const es = {
     deleteConfirm: 'Eliminar permanentemente {{symbol}} del {{date}}. Los dividendos importados están protegidos y deben reimportarse para eliminarse.',
     importTitle: 'Importar dividendos',
     importDescription: 'Sube un Estado de actividad de IBKR (CSV) o una exportación de operaciones de MyInvestor (XLS). El bróker se detecta automáticamente. Reimportar es seguro: los existentes se actualizan, los manuales no se tocan.',
-    importPickFile: 'Elige un archivo CSV',
+    importPickFile: 'Elige un archivo (CSV o XLS)',
     importHint: 'Estado de actividad de IBKR (CSV) o exportación de operaciones de MyInvestor (XLS).',
     importIbkrPathLabel: 'Dónde encontrarlo en IBKR:',
     importIbkrPathEn: 'EN: Performance & Reports → Statements → Activity',


### PR DESCRIPTION
The file dropzone label still said \"Pick a CSV file\" even though we now accept XLS too (MyInvestor exports). Updated to \"Pick a file (CSV or XLS)\" in en + es. Tiny copy fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)