### PR TITLE
Include radar stocks in Upcoming Ex-divs

### DIFF
--- a/app/frontend/components/UpcomingExDividends.tsx
+++ b/app/frontend/components/UpcomingExDividends.tsx
@@ -3,24 +3,29 @@ import { CalendarClock } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { StockLogo } from './StockLogo'
 import { Card, CardContent } from '@/components/ui/card'
+import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
-import type { Holding } from '../types'
+import type { Holding, RadarStock, Stock } from '../types'
 
 interface Props {
   holdings: Holding[]
+  radarStocks?: RadarStock[]
   daysAhead?: number
 }
 
 interface UpcomingItem {
-  holding: Holding
+  stock: Stock | RadarStock
+  source: 'holding' | 'radar'
   daysUntil: number
   exDivDate: Date
+  key: string
 }
 
-// Compact card listing the user's holdings whose ex-dividend date falls within
-// the next `daysAhead` days, sorted soonest-first. Hides itself when there
-// are no upcoming ex-divs so the page doesn't show empty noise.
-export function UpcomingExDividends({ holdings, daysAhead = 14 }: Props) {
+// Compact card listing the user's stocks (held + watching) whose ex-dividend
+// date falls within the next `daysAhead` days, sorted soonest-first. Holdings
+// take precedence — a stock that's both held and on radar appears once,
+// untagged. Radar-only stocks get a small "Radar" tag.
+export function UpcomingExDividends({ holdings, radarStocks = [], daysAhead = 14 }: Props) {
   const { t, i18n } = useTranslation()
 
   const upcoming = useMemo<UpcomingItem[]>(() => {
@@ -29,18 +34,30 @@ export function UpcomingExDividends({ holdings, daysAhead = 14 }: Props) {
     const horizon = new Date(startOfToday)
     horizon.setDate(horizon.getDate() + daysAhead)
 
-    return holdings
-      .map((h) => {
-        if (!h.stock.exDividendDate) return null
-        const exDivDate = new Date(h.stock.exDividendDate)
-        if (isNaN(exDivDate.getTime())) return null
-        if (exDivDate < startOfToday || exDivDate > horizon) return null
-        const daysUntil = Math.round((exDivDate.getTime() - startOfToday.getTime()) / (1000 * 60 * 60 * 24))
-        return { holding: h, daysUntil, exDivDate }
-      })
-      .filter((x): x is UpcomingItem => x !== null)
-      .sort((a, b) => a.daysUntil - b.daysUntil)
-  }, [holdings, daysAhead])
+    const heldStockIds = new Set(holdings.map((h) => h.stock.id))
+    const items: UpcomingItem[] = []
+
+    const inWindow = (stock: Stock): { exDivDate: Date; daysUntil: number } | null => {
+      if (!stock.exDividendDate) return null
+      const exDivDate = new Date(stock.exDividendDate)
+      if (isNaN(exDivDate.getTime())) return null
+      if (exDivDate < startOfToday || exDivDate > horizon) return null
+      const daysUntil = Math.round((exDivDate.getTime() - startOfToday.getTime()) / (1000 * 60 * 60 * 24))
+      return { exDivDate, daysUntil }
+    }
+
+    for (const h of holdings) {
+      const w = inWindow(h.stock)
+      if (w) items.push({ stock: h.stock, source: 'holding', key: `h-${h.id}`, ...w })
+    }
+    for (const rs of radarStocks) {
+      if (heldStockIds.has(rs.id)) continue // already covered by holding
+      const w = inWindow(rs)
+      if (w) items.push({ stock: rs, source: 'radar', key: `r-${rs.id}`, ...w })
+    }
+
+    return items.sort((a, b) => a.daysUntil - b.daysUntil)
+  }, [holdings, radarStocks, daysAhead])
 
   if (upcoming.length === 0) return null
 
@@ -58,17 +75,24 @@ export function UpcomingExDividends({ holdings, daysAhead = 14 }: Props) {
           <span className="text-xs text-muted-foreground tabular-nums">{upcoming.length}</span>
         </div>
         <ul className="space-y-1.5">
-          {upcoming.map(({ holding, daysUntil, exDivDate }) => {
+          {upcoming.map(({ stock, source, daysUntil, exDivDate, key }) => {
             const urgent = daysUntil <= 3
             return (
               <li
-                key={holding.id}
+                key={key}
                 className="flex items-center gap-2 px-2 py-1.5 rounded-md hover:bg-muted/40"
               >
-                <StockLogo symbol={holding.stock.symbol} name={holding.stock.name} size="sm" />
+                <StockLogo symbol={stock.symbol} name={stock.name} size="sm" />
                 <div className="flex-1 min-w-0">
-                  <p className="text-sm font-semibold leading-tight">{holding.stock.symbol}</p>
-                  <p className="text-[11px] text-muted-foreground truncate">{holding.stock.name}</p>
+                  <p className="text-sm font-semibold leading-tight flex items-center gap-1.5">
+                    {stock.symbol}
+                    {source === 'radar' && (
+                      <Badge variant="outline" className="text-[9px] px-1 py-0 uppercase tracking-wide">
+                        {t('dividends.upcomingRadarTag')}
+                      </Badge>
+                    )}
+                  </p>
+                  <p className="text-[11px] text-muted-foreground truncate">{stock.name}</p>
                 </div>
                 <span className="text-xs font-mono text-muted-foreground tabular-nums whitespace-nowrap">
                   {formatDate(exDivDate)}

--- a/app/frontend/locales/en.ts
+++ b/app/frontend/locales/en.ts
@@ -246,6 +246,7 @@ const en = {
     chartActual: 'Received',
     chartProjected: 'Projected',
     upcomingExDivs: 'Upcoming ex-dividends · next {{count}} days',
+    upcomingRadarTag: 'Radar',
   },
 
   // Stock metrics (shared across card types)

--- a/app/frontend/locales/es.ts
+++ b/app/frontend/locales/es.ts
@@ -246,6 +246,7 @@ const es = {
     chartActual: 'Recibidos',
     chartProjected: 'Estimados',
     upcomingExDivs: 'Próximos ex-dividend · {{count}} días',
+    upcomingRadarTag: 'Radar',
   },
 
   // Stock metrics

--- a/app/frontend/pages/DividendsPage.tsx
+++ b/app/frontend/pages/DividendsPage.tsx
@@ -2,6 +2,7 @@ import { useState, useMemo } from 'react'
 import { Loader2, Plus, Upload, Trash2, Pencil, Coins } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useHoldings } from '../hooks/useHoldingsQueries'
+import { useRadar } from '../hooks/useRadarQueries'
 import { useDividends, useDeleteDividend, useDividendChartData } from '../hooks/useDividendsQueries'
 import { DividendFormDialog } from '../components/DividendFormDialog'
 import { DividendImportDialog } from '../components/DividendImportDialog'
@@ -29,6 +30,7 @@ export function DividendsPage() {
   const { data: chartData } = useDividendChartData()
   const { data: chartDataFull } = useDividendChartData('full')
   const { data: holdingsData } = useHoldings()
+  const { data: radarData } = useRadar()
   const deleteMutation = useDeleteDividend()
 
   const [formOpen, setFormOpen] = useState(false)
@@ -119,9 +121,12 @@ export function DividendsPage() {
             </div>
           )}
 
-          {holdingsData?.holdings && holdingsData.holdings.length > 0 && (
+          {((holdingsData?.holdings?.length ?? 0) > 0 || (radarData?.stocks?.length ?? 0) > 0) && (
             <div className="mb-6">
-              <UpcomingExDividends holdings={holdingsData.holdings} />
+              <UpcomingExDividends
+                holdings={holdingsData?.holdings ?? []}
+                radarStocks={radarData?.stocks ?? []}
+              />
             </div>
           )}
 


### PR DESCRIPTION
Follow-up to #160. Previously the Upcoming Ex-divs card on /dividends listed only portfolio holdings — but a stock you're watching on the radar may also have an ex-div coming up that you'd want to time a buy around.

- Pull radar stocks via \`useRadar\` alongside the existing \`useHoldings\`
- Merge into one list inside \`UpcomingExDividends\`, dedupe by stock_id (holdings win, since they carry the more relevant context)
- Radar-only items get a small \`Radar\` outline badge after the symbol so they're visually distinct from held positions
- en + es locale key

🤖 Generated with [Claude Code](https://claude.com/claude-code)