### PR TITLE
Bump Gemini social-post token limit to fix intermittent truncation

### DIFF
--- a/app/services/ai_providers/gemini_provider.rb
+++ b/app/services/ai_providers/gemini_provider.rb
@@ -49,12 +49,15 @@ module AiProviders
     # Generate a social-media post for X and LinkedIn from a content topic.
     # Topic shape: { category:, topic_key:, inputs: {…} }. No caching: every
     # button click should produce a fresh draft, not return a stale one.
-    # Bumped max_output_tokens because the LinkedIn body (≤1500 chars) plus
-    # X text plus headline plus JSON overhead overflows the default 1024.
+    # max_output_tokens needs comfortable headroom because the LinkedIn body
+    # (≤1500 chars) plus X text plus headline plus JSON schema overhead can
+    # spike past lower limits when Gemini's sampling lands on a wordy response
+    # — hitting it caused intermittent "response not valid JSON (truncated)"
+    # errors. 4096 is well within Flash's 8192 cap and leaves slack.
     def social_post(topic, locale: nil)
       lang = normalized_locale(locale)
       prompt = build_social_post_prompt(topic, lang)
-      response = call_gemini(prompt, social_post_response_schema, max_output_tokens: 2048)
+      response = call_gemini(prompt, social_post_response_schema, max_output_tokens: 4096)
       parse_response(response)
     end
 


### PR DESCRIPTION
The 'Gemini response was not valid JSON (likely truncated)' error has been firing intermittently on social-draft generation. The 'mobile vs desktop' angle is coincidence — locale isn't passed (always English), so the actual cause is non-deterministic sampling at \`temperature: 0.7\` landing on a wordier response that overflows the 2048-token cap.

LinkedIn body (≤1500 chars) + X text + headline + hashtags + JSON schema overhead leaves little slack at 2048. Bumping to 4096, well within Flash's 8192 ceiling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)