### PR TITLE
Add anonymous demo mode at /demo with sign-up nudge on writes

### DIFF
--- a/app/controllers/api/v1/demos_controller.rb
+++ b/app/controllers/api/v1/demos_controller.rb
@@ -1,0 +1,15 @@
+module Api
+  module V1
+    # Public endpoint serving the curated demo bundle for anonymous visitors
+    # browsing `/demo`. No DB writes, no broadcast, no caching — just a static
+    # JSON snapshot.
+    class DemosController < BaseController
+      allow_unauthenticated_access only: [ :show ]
+
+      # GET /api/v1/demo
+      def show
+        render_success(Demos::DataBundle.call)
+      end
+    end
+  end
+end

--- a/app/frontend/components/App.tsx
+++ b/app/frontend/components/App.tsx
@@ -11,7 +11,7 @@
  */
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { BrowserRouter, Routes, Route } from 'react-router-dom'
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom'
 import { ThemeProvider } from '../contexts/ThemeContext'
 import { ViewPreferenceProvider } from '../contexts/ViewPreferenceContext'
 import { AuthProvider } from '../contexts/AuthContext'
@@ -28,6 +28,7 @@ import AdminContentDraftsPage from '../pages/AdminContentDraftsPage'
 import PortfolioPage from '../pages/PortfolioPage'
 import DividendsPage from '../pages/DividendsPage'
 import SettingsPage from '../pages/SettingsPage'
+import DemoPage from '../pages/DemoPage'
 
 /**
  * QueryClient Configuration
@@ -78,6 +79,12 @@ function App() {
                     <Route element={<AdminRoute />}>
                       <Route path="/admin" element={<AdminDashboardPage />} />
                       <Route path="/admin/content-drafts" element={<AdminContentDraftsPage />} />
+                    </Route>
+                    <Route element={<DemoPage />}>
+                      <Route path="/demo" element={<Navigate to="/demo/portfolio" replace />} />
+                      <Route path="/demo/radar" element={<RadarPage />} />
+                      <Route path="/demo/portfolio" element={<PortfolioPage />} />
+                      <Route path="/demo/dividends" element={<DividendsPage />} />
                     </Route>
                   </Route>
                 </Routes>

--- a/app/frontend/components/DemoBanner.tsx
+++ b/app/frontend/components/DemoBanner.tsx
@@ -1,0 +1,21 @@
+import { Sparkles } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+import { Button } from '@/components/ui/button'
+
+export function DemoBanner() {
+  const { t } = useTranslation()
+  return (
+    <div className="bg-gradient-to-r from-emerald-500/10 via-emerald-500/15 to-teal-500/10 border-b border-emerald-500/20">
+      <div className="container mx-auto px-4 py-2.5 flex items-center justify-between gap-3 flex-wrap">
+        <p className="flex items-center gap-2 text-sm">
+          <Sparkles className="size-4 text-emerald-600 dark:text-emerald-400 shrink-0" />
+          <span>{t('demo.banner.message')}</span>
+        </p>
+        <Button asChild size="sm" className="bg-emerald-600 hover:bg-emerald-700 text-white">
+          <Link to="/signup">{t('demo.banner.cta')}</Link>
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/app/frontend/components/Layout.tsx
+++ b/app/frontend/components/Layout.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react'
-import { Link, NavLink, Outlet, useNavigate } from 'react-router-dom'
+import { Link, NavLink, Outlet, useLocation, useNavigate } from 'react-router-dom'
 import { Menu } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useAuth } from '../contexts/AuthContext'
 import { Logo } from './Logo'
 import { ThemeToggle } from './ThemeToggle'
 import { LanguageToggle } from './LanguageToggle'
+import { DemoBanner } from './DemoBanner'
 import { Button } from '@/components/ui/button'
 import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '@/components/ui/sheet'
 import { Separator } from '@/components/ui/separator'
@@ -27,8 +28,15 @@ const mobileNavLinkClass = ({ isActive }: { isActive: boolean }) =>
 export function Layout() {
   const { user, isAuthenticated, isLoading, logout } = useAuth()
   const navigate = useNavigate()
+  const location = useLocation()
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const { t } = useTranslation()
+
+  // /demo/* is the anonymous "try the product" route. The Layout adapts: nav
+  // links point at the demo equivalents, the right-side "Sign in" CTA flips
+  // to a stronger "Sign up", and a banner sits above the header.
+  const isDemo = location.pathname.startsWith('/demo')
+  const navTarget = (path: string) => (isDemo ? `/demo${path}` : path)
 
   const handleLogout = async () => {
     await logout()
@@ -39,6 +47,7 @@ export function Layout() {
 
   return (
     <div className="min-h-screen bg-background flex flex-col">
+      {isDemo && <DemoBanner />}
       {/* Header */}
       <header className="sticky top-0 z-50 bg-background border-b shadow-sm">
         <div className="container mx-auto px-4">
@@ -51,12 +60,14 @@ export function Layout() {
             <nav className="hidden md:flex items-center gap-2 lg:gap-4">
               <NavLink to="/" end className={navLinkClass}>{t('nav.home')}</NavLink>
 
-              {isAuthenticated && (
+              {(isAuthenticated || isDemo) && (
                 <>
-                  <NavLink to="/radar" className={navLinkClass}>{t('nav.radar')}</NavLink>
-                  <NavLink to="/portfolio" className={navLinkClass}>{t('nav.portfolio')}</NavLink>
-                  <NavLink to="/dividends" className={navLinkClass}>{t('nav.dividends')}</NavLink>
-                  <NavLink to="/settings" className={navLinkClass}>{t('nav.settings')}</NavLink>
+                  <NavLink to={navTarget('/radar')} className={navLinkClass}>{t('nav.radar')}</NavLink>
+                  <NavLink to={navTarget('/portfolio')} className={navLinkClass}>{t('nav.portfolio')}</NavLink>
+                  <NavLink to={navTarget('/dividends')} className={navLinkClass}>{t('nav.dividends')}</NavLink>
+                  {isAuthenticated && (
+                    <NavLink to="/settings" className={navLinkClass}>{t('nav.settings')}</NavLink>
+                  )}
                 </>
               )}
 
@@ -80,7 +91,7 @@ export function Layout() {
                       {t('nav.logout')}
                     </Button>
                   </div>
-                ) : (
+                ) : isDemo ? null : (
                   <Button asChild size="sm">
                     <Link to="/login">{t('nav.signIn')}</Link>
                   </Button>
@@ -110,12 +121,14 @@ export function Layout() {
           <nav className="flex flex-col gap-1 p-4">
             <NavLink to="/" end className={mobileNavLinkClass} onClick={closeMobile}>{t('nav.home')}</NavLink>
 
-            {isAuthenticated && (
+            {(isAuthenticated || isDemo) && (
               <>
-                <NavLink to="/radar" className={mobileNavLinkClass} onClick={closeMobile}>{t('nav.radar')}</NavLink>
-                <NavLink to="/portfolio" className={mobileNavLinkClass} onClick={closeMobile}>{t('nav.portfolio')}</NavLink>
-                <NavLink to="/dividends" className={mobileNavLinkClass} onClick={closeMobile}>{t('nav.dividends')}</NavLink>
-                <NavLink to="/settings" className={mobileNavLinkClass} onClick={closeMobile}>{t('nav.settings')}</NavLink>
+                <NavLink to={navTarget('/radar')} className={mobileNavLinkClass} onClick={closeMobile}>{t('nav.radar')}</NavLink>
+                <NavLink to={navTarget('/portfolio')} className={mobileNavLinkClass} onClick={closeMobile}>{t('nav.portfolio')}</NavLink>
+                <NavLink to={navTarget('/dividends')} className={mobileNavLinkClass} onClick={closeMobile}>{t('nav.dividends')}</NavLink>
+                {isAuthenticated && (
+                  <NavLink to="/settings" className={mobileNavLinkClass} onClick={closeMobile}>{t('nav.settings')}</NavLink>
+                )}
               </>
             )}
 
@@ -140,7 +153,7 @@ export function Layout() {
                   {t('nav.logout')}
                 </Button>
               </>
-            ) : (
+            ) : isDemo ? null : (
               <Button asChild className="mx-4">
                 <Link to="/login" onClick={closeMobile}>{t('nav.signIn')}</Link>
               </Button>

--- a/app/frontend/components/SignupNudgeDialog.tsx
+++ b/app/frontend/components/SignupNudgeDialog.tsx
@@ -1,0 +1,40 @@
+import { Sparkles } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+import {
+  AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent,
+  AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { useDemoMode } from '../contexts/DemoModeContext'
+
+// Layout-level modal shown when a write action is attempted in demo mode.
+// Body copy is keyed by the action so the message reads naturally.
+export function SignupNudgeDialog() {
+  const { t } = useTranslation()
+  const { nudgeAction, dismissNudge } = useDemoMode()
+
+  const open = nudgeAction !== null
+  const bodyKey = nudgeAction ? `demo.nudge.bodies.${nudgeAction}` : ''
+
+  return (
+    <AlertDialog open={open} onOpenChange={(o) => { if (!o) dismissNudge() }}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle className="flex items-center gap-2">
+            <Sparkles className="size-5 text-emerald-500" />
+            {t('demo.nudge.title')}
+          </AlertDialogTitle>
+          <AlertDialogDescription>
+            {nudgeAction ? t(bodyKey) : ''}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>{t('demo.nudge.keepExploring')}</AlertDialogCancel>
+          <AlertDialogAction asChild onClick={dismissNudge}>
+            <Link to="/signup">{t('demo.nudge.signUp')}</Link>
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/app/frontend/contexts/DemoModeContext.tsx
+++ b/app/frontend/contexts/DemoModeContext.tsx
@@ -1,0 +1,53 @@
+import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from 'react'
+
+// Keys identify which write action triggered the sign-up nudge — the dialog
+// uses them to pick the right body copy. Keep these stable; locales reference
+// them via `t('demo.nudge.bodies.<key>')`.
+export type NudgeAction =
+  | 'addRadarStock'
+  | 'updateTargetPrice'
+  | 'addHolding'
+  | 'updateHolding'
+  | 'deleteHolding'
+  | 'addDividend'
+  | 'editDividend'
+  | 'deleteDividend'
+  | 'importDividends'
+  | 'updateProfile'
+
+interface DemoModeContextValue {
+  isDemoMode: boolean
+  nudgeAction: NudgeAction | null
+  triggerNudge: (action: NudgeAction) => void
+  dismissNudge: () => void
+}
+
+const DemoModeContext = createContext<DemoModeContextValue>({
+  isDemoMode: false,
+  nudgeAction: null,
+  triggerNudge: () => {},
+  dismissNudge: () => {},
+})
+
+interface ProviderProps {
+  children: ReactNode
+  isDemoMode?: boolean
+}
+
+export function DemoModeProvider({ children, isDemoMode = false }: ProviderProps) {
+  const [nudgeAction, setNudgeAction] = useState<NudgeAction | null>(null)
+
+  const triggerNudge = useCallback((action: NudgeAction) => setNudgeAction(action), [])
+  const dismissNudge = useCallback(() => setNudgeAction(null), [])
+
+  const value = useMemo(
+    () => ({ isDemoMode, nudgeAction, triggerNudge, dismissNudge }),
+    [isDemoMode, nudgeAction, triggerNudge, dismissNudge]
+  )
+
+  return <DemoModeContext.Provider value={value}>{children}</DemoModeContext.Provider>
+}
+
+export function useDemoMode() {
+  return useContext(DemoModeContext)
+}

--- a/app/frontend/hooks/useDemoGuardedMutation.ts
+++ b/app/frontend/hooks/useDemoGuardedMutation.ts
@@ -1,0 +1,41 @@
+import { useMutation, type UseMutationOptions, type UseMutationResult } from '@tanstack/react-query'
+import { useDemoMode, type NudgeAction } from '../contexts/DemoModeContext'
+
+// Tagged Error so callers can choose to swallow demo blocks silently.
+export class DemoModeBlockedError extends Error {
+  constructor() {
+    super('demo-mode-blocked')
+    this.name = 'DemoModeBlockedError'
+  }
+}
+
+export function isDemoBlockedError(err: unknown): boolean {
+  return err instanceof DemoModeBlockedError || (err instanceof Error && err.message === 'demo-mode-blocked')
+}
+
+// Wraps `useMutation` so that, when the surrounding `DemoModeProvider` reports
+// demo mode, calling `.mutate()` or `.mutateAsync()` short-circuits: it
+// triggers the sign-up nudge with the supplied `action` key, doesn't hit the
+// API, and (for the async variant) rejects with `DemoModeBlockedError` so
+// callers can opt-in to silent handling. Behaves identically to a regular
+// `useMutation` outside demo mode.
+export function useDemoGuardedMutation<TData = unknown, TError = Error, TVariables = void, TContext = unknown>(
+  action: NudgeAction,
+  options: UseMutationOptions<TData, TError, TVariables, TContext>,
+): UseMutationResult<TData, TError, TVariables, TContext> {
+  const { isDemoMode, triggerNudge } = useDemoMode()
+  const mutation = useMutation(options)
+
+  if (!isDemoMode) return mutation
+
+  const blockedMutate = ((..._args: unknown[]) => {
+    triggerNudge(action)
+  }) as UseMutationResult<TData, TError, TVariables, TContext>['mutate']
+
+  const blockedMutateAsync = ((..._args: unknown[]) => {
+    triggerNudge(action)
+    return Promise.reject(new DemoModeBlockedError())
+  }) as UseMutationResult<TData, TError, TVariables, TContext>['mutateAsync']
+
+  return { ...mutation, mutate: blockedMutate, mutateAsync: blockedMutateAsync }
+}

--- a/app/frontend/hooks/useDividendsQueries.ts
+++ b/app/frontend/hooks/useDividendsQueries.ts
@@ -1,10 +1,11 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import {
   dividendsApi,
   type DividendCreatePayload,
   type DividendUpdatePayload,
   type DividendImportRow,
 } from '../lib/api'
+import { useDemoGuardedMutation } from './useDemoGuardedMutation'
 
 const KEY = ['dividends'] as const
 
@@ -26,7 +27,7 @@ export function useDividendChartData(range?: 'full') {
 
 export function useCreateDividend() {
   const qc = useQueryClient()
-  return useMutation({
+  return useDemoGuardedMutation('addDividend', {
     mutationFn: (payload: DividendCreatePayload) => dividendsApi.create(payload),
     onSuccess: () => qc.invalidateQueries({ queryKey: KEY }),
   })
@@ -34,7 +35,7 @@ export function useCreateDividend() {
 
 export function useUpdateDividend() {
   const qc = useQueryClient()
-  return useMutation({
+  return useDemoGuardedMutation('editDividend', {
     mutationFn: ({ id, payload }: { id: number; payload: DividendUpdatePayload }) =>
       dividendsApi.update(id, payload),
     onSuccess: () => qc.invalidateQueries({ queryKey: KEY }),
@@ -43,21 +44,21 @@ export function useUpdateDividend() {
 
 export function useDeleteDividend() {
   const qc = useQueryClient()
-  return useMutation({
+  return useDemoGuardedMutation('deleteDividend', {
     mutationFn: (id: number) => dividendsApi.delete(id),
     onSuccess: () => qc.invalidateQueries({ queryKey: KEY }),
   })
 }
 
 export function useDividendImportPreview() {
-  return useMutation({
+  return useDemoGuardedMutation('importDividends', {
     mutationFn: (file: File) => dividendsApi.importPreview(file),
   })
 }
 
 export function useDividendImportApply() {
   const qc = useQueryClient()
-  return useMutation({
+  return useDemoGuardedMutation('importDividends', {
     mutationFn: ({ rows, mapping, source }: { rows: DividendImportRow[]; mapping: Record<string, number>; source?: string }) =>
       dividendsApi.importApply(rows, mapping, source),
     onSuccess: () => qc.invalidateQueries({ queryKey: KEY }),

--- a/app/frontend/hooks/useHoldingsQueries.ts
+++ b/app/frontend/hooks/useHoldingsQueries.ts
@@ -1,5 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { holdingsApi } from '../lib/api'
+import { useDemoGuardedMutation } from './useDemoGuardedMutation'
 import type { CurrencyTotals, Holding, HoldingsResponse } from '../types'
 
 // Recompute per-currency totals after an optimistic delete. The portfolio can
@@ -36,7 +37,7 @@ export function useHoldings() {
 export function useCreateHolding() {
   const queryClient = useQueryClient()
 
-  return useMutation({
+  return useDemoGuardedMutation('addHolding', {
     mutationFn: ({ stockId, quantity, averagePrice }: { stockId: number; quantity: number; averagePrice: number }) =>
       holdingsApi.create(stockId, quantity, averagePrice),
     onSuccess: () => {
@@ -48,7 +49,7 @@ export function useCreateHolding() {
 export function useUpdateHolding() {
   const queryClient = useQueryClient()
 
-  return useMutation({
+  return useDemoGuardedMutation('updateHolding', {
     mutationFn: ({ id, quantity, averagePrice }: { id: number; quantity: number; averagePrice: number }) =>
       holdingsApi.update(id, quantity, averagePrice),
     onSuccess: () => {
@@ -60,7 +61,7 @@ export function useUpdateHolding() {
 export function useDeleteHolding() {
   const queryClient = useQueryClient()
 
-  return useMutation({
+  return useDemoGuardedMutation('deleteHolding', {
     mutationFn: (id: number) => holdingsApi.delete(id),
     onMutate: async (id) => {
       await queryClient.cancelQueries({ queryKey: ['holdings'] })

--- a/app/frontend/hooks/useProfileQueries.ts
+++ b/app/frontend/hooks/useProfileQueries.ts
@@ -1,5 +1,6 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { profileApi, type ProfileUpdate } from '../lib/api'
+import { useDemoGuardedMutation } from './useDemoGuardedMutation'
 
 export function useProfile() {
   return useQuery({
@@ -12,7 +13,7 @@ export function useProfile() {
 export function useUpdateProfile() {
   const queryClient = useQueryClient()
 
-  return useMutation({
+  return useDemoGuardedMutation('updateProfile', {
     mutationFn: (update: ProfileUpdate) => profileApi.update(update),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['profile'] })

--- a/app/frontend/hooks/useRadarQueries.ts
+++ b/app/frontend/hooks/useRadarQueries.ts
@@ -18,8 +18,9 @@
  * so it refetches fresh data. This keeps the UI in sync.
  */
 
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { radarApi } from '../lib/api'
+import { useDemoGuardedMutation } from './useDemoGuardedMutation'
 
 /**
  * Fetch the user's radar (watchlist)
@@ -52,7 +53,7 @@ export function useRadar() {
 export function useAddStock() {
   const queryClient = useQueryClient()
 
-  return useMutation({
+  return useDemoGuardedMutation('addRadarStock', {
     mutationFn: (stockId: number) => radarApi.addStock(stockId),
     onSuccess: () => {
       // Invalidate radar query to refetch updated data
@@ -71,7 +72,7 @@ export function useAddStock() {
 export function useRemoveStock() {
   const queryClient = useQueryClient()
 
-  return useMutation({
+  return useDemoGuardedMutation('addRadarStock', {
     mutationFn: (stockId: number) => radarApi.removeStock(stockId),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['radar'] })
@@ -89,7 +90,7 @@ export function useRemoveStock() {
 export function useUpdateTargetPrice() {
   const queryClient = useQueryClient()
 
-  return useMutation({
+  return useDemoGuardedMutation('updateTargetPrice', {
     mutationFn: ({ stockId, price }: { stockId: number; price: number | null }) =>
       radarApi.updateTargetPrice(stockId, price),
     onSuccess: () => {

--- a/app/frontend/lib/api.ts
+++ b/app/frontend/lib/api.ts
@@ -138,6 +138,21 @@ interface RadarResponse {
   stocks: RadarStock[]
 }
 
+// Curated bundle returned by the public /demo endpoint. Each section's shape
+// matches the corresponding endpoint's JSON, so React Query can cache it under
+// the same keys the regular hooks read from (['radar'], ['holdings'], etc.).
+export interface DemoBundle {
+  radar: RadarResponse
+  holdings: unknown
+  dividends: unknown[]
+  chart: unknown
+  chartFull: unknown
+}
+
+export const demoApi = {
+  get: () => apiFetch<DemoBundle>('/demo'),
+}
+
 export const radarApi = {
   /**
    * Get the current user's radar with all stocks

--- a/app/frontend/locales/en.ts
+++ b/app/frontend/locales/en.ts
@@ -78,6 +78,33 @@ const en = {
     noTopScored: 'No top scored stocks available.',
     inRadar: 'In Radar',
     addToRadar: 'Add to Radar',
+    tryDemo: 'Try a sample portfolio',
+  },
+
+  // Demo mode
+  demo: {
+    banner: {
+      message: "You're exploring a sample portfolio. Sign up to build your own.",
+      cta: 'Sign up',
+    },
+    loadError: "Couldn't load the demo: {{message}}",
+    nudge: {
+      title: 'Sign up to make this yours',
+      signUp: 'Sign up — it’s free',
+      keepExploring: 'Keep exploring',
+      bodies: {
+        addRadarStock: 'Add stocks to your own radar to track them with target prices and live status.',
+        updateTargetPrice: 'Set your own target prices and get visual cues when stocks dip below.',
+        addHolding: 'Add holdings to track your real portfolio value, yield, and sector mix.',
+        updateHolding: 'Edit your holdings to keep your portfolio in sync with reality.',
+        deleteHolding: 'Manage your holdings — add, edit, and remove them as your portfolio evolves.',
+        addDividend: 'Log dividends to see your income calendar, sector mix, and year-on-year growth.',
+        editDividend: 'Edit dividend entries to correct dates, amounts, or sources.',
+        deleteDividend: 'Manage your dividend history — remove duplicates or mistakes.',
+        importDividends: 'Bulk-import dividends from your broker (Interactive Brokers, CSV, and more).',
+        updateProfile: 'Personalize your account — default currency, locale, and pulse sharing.',
+      },
+    },
   },
 
   // Feature Showcase

--- a/app/frontend/locales/es.ts
+++ b/app/frontend/locales/es.ts
@@ -78,6 +78,33 @@ const es = {
     noTopScored: 'No hay acciones con puntuaci\u00f3n disponibles.',
     inRadar: 'En Radar',
     addToRadar: 'A\u00f1adir al Radar',
+    tryDemo: 'Prueba una cartera de ejemplo',
+  },
+
+  // Demo mode
+  demo: {
+    banner: {
+      message: 'Est\u00e1s explorando una cartera de ejemplo. Reg\u00edstrate para crear la tuya.',
+      cta: 'Reg\u00edstrate',
+    },
+    loadError: 'No se pudo cargar el demo: {{message}}',
+    nudge: {
+      title: 'Reg\u00edstrate para que sea tuyo',
+      signUp: 'Reg\u00edstrate \u2014 es gratis',
+      keepExploring: 'Seguir explorando',
+      bodies: {
+        addRadarStock: 'A\u00f1ade acciones a tu propio radar para seguirlas con precios objetivo y estado en vivo.',
+        updateTargetPrice: 'Fija tus propios precios objetivo y recibe se\u00f1ales visuales cuando bajen.',
+        addHolding: 'A\u00f1ade posiciones para ver el valor real de tu cartera, rentabilidad y reparto sectorial.',
+        updateHolding: 'Edita tus posiciones para mantener tu cartera al d\u00eda.',
+        deleteHolding: 'Gestiona tus posiciones \u2014 a\u00f1ade, edita y elimina seg\u00fan evolucione tu cartera.',
+        addDividend: 'Registra dividendos para ver tu calendario de ingresos, reparto sectorial y crecimiento interanual.',
+        editDividend: 'Edita entradas de dividendos para corregir fechas, importes o fuentes.',
+        deleteDividend: 'Gestiona tu historial de dividendos \u2014 elimina duplicados o errores.',
+        importDividends: 'Importa dividendos en lote desde tu broker (Interactive Brokers, CSV y m\u00e1s).',
+        updateProfile: 'Personaliza tu cuenta \u2014 moneda por defecto, idioma y compartir en Pulse.',
+      },
+    },
   },
 
   // Feature Showcase

--- a/app/frontend/pages/DemoPage.tsx
+++ b/app/frontend/pages/DemoPage.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react'
+import { Loader2 } from 'lucide-react'
+import { Navigate, Outlet } from 'react-router-dom'
+import { useQueryClient } from '@tanstack/react-query'
+import { useTranslation } from 'react-i18next'
+import { demoApi } from '../lib/api'
+import { useAuth } from '../contexts/AuthContext'
+import { DemoModeProvider } from '../contexts/DemoModeContext'
+import { SignupNudgeDialog } from '../components/SignupNudgeDialog'
+
+// Outlet wrapper that powers all /demo/* routes. Fetches the curated bundle
+// once, primes React Query under the keys the regular hooks read from
+// (['radar'], ['holdings'], ['dividends'], ['dividends', 'chart', ...]), then
+// renders the same Radar / Portfolio / Dividends pages — they read from the
+// prefilled cache and never know they're in a demo.
+export function DemoPage() {
+  const { t } = useTranslation()
+  const queryClient = useQueryClient()
+  const { isAuthenticated, isLoading: authLoading } = useAuth()
+  const [ready, setReady] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  // Demo is for anonymous visitors only. Skip the fetch when the user is
+  // signed in (or while auth is still resolving) — the early-return below
+  // will redirect them.
+  const skipFetch = authLoading || isAuthenticated
+
+  useEffect(() => {
+    if (skipFetch) return
+    let cancelled = false
+    demoApi
+      .get()
+      .then((bundle) => {
+        if (cancelled) return
+        queryClient.setQueryData(['radar'], bundle.radar)
+        queryClient.setQueryData(['holdings'], bundle.holdings)
+        queryClient.setQueryData(['dividends'], bundle.dividends)
+        queryClient.setQueryData(['dividends', 'chart', 'default'], bundle.chart)
+        queryClient.setQueryData(['dividends', 'chart', 'full'], bundle.chartFull)
+        setReady(true)
+      })
+      .catch((err) => {
+        if (cancelled) return
+        setError(err instanceof Error ? err.message : String(err))
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [queryClient, skipFetch])
+
+  // Wipe demo prefill on unmount so a subsequent sign-up + navigation gets
+  // the real (empty) user data — not demo data leaking into the account.
+  useEffect(() => {
+    return () => {
+      queryClient.removeQueries({ queryKey: ['radar'] })
+      queryClient.removeQueries({ queryKey: ['holdings'] })
+      queryClient.removeQueries({ queryKey: ['dividends'] })
+    }
+  }, [queryClient])
+
+  if (authLoading) {
+    return (
+      <div className="container mx-auto px-4 py-12 text-center">
+        <Loader2 className="size-8 animate-spin text-muted-foreground mx-auto" />
+      </div>
+    )
+  }
+  if (isAuthenticated) {
+    return <Navigate to="/portfolio" replace />
+  }
+
+  if (error) {
+    return (
+      <div className="container mx-auto px-4 py-12 text-center">
+        <p className="text-destructive">{t('demo.loadError', { message: error })}</p>
+      </div>
+    )
+  }
+
+  if (!ready) {
+    return (
+      <div className="container mx-auto px-4 py-12 text-center">
+        <Loader2 className="size-8 animate-spin text-muted-foreground mx-auto" />
+      </div>
+    )
+  }
+
+  return (
+    <DemoModeProvider isDemoMode>
+      <Outlet />
+      <SignupNudgeDialog />
+    </DemoModeProvider>
+  )
+}
+
+export default DemoPage

--- a/app/frontend/pages/HomePage.tsx
+++ b/app/frontend/pages/HomePage.tsx
@@ -1,18 +1,21 @@
-import { Loader2, Activity, ExternalLink, Settings } from 'lucide-react'
+import { Loader2, Activity, ExternalLink, Settings, Sparkles } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { Logo } from '../components/Logo'
 import { FeatureShowcase } from '../components/FeatureShowcase'
 import { TopScoredShowcase } from '../components/TopScoredShowcase'
 import { CompactStockRow } from '../components/CompactStockRow'
+import { useAuth } from '../contexts/AuthContext'
 import { useLastAddedStocks, useMostAddedStocks, useMostHeldStocks } from '../hooks/useStockQueries'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Button } from '@/components/ui/button'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import pulsePreviewImg from '@/assets/screenshots/pulse-portfolio.webp'
 import { PULSE_URL } from '../lib/pulse'
 
 export function HomePage() {
   const { t } = useTranslation()
+  const { isAuthenticated } = useAuth()
 
   const {
     data: lastAdded,
@@ -49,6 +52,15 @@ export function HomePage() {
         <p className="text-muted-foreground text-base sm:text-lg max-w-2xl mx-auto">
           {t('home.heroSubtitle')}
         </p>
+        {!isAuthenticated && (
+          <div className="flex flex-wrap items-center justify-center gap-3 mt-5">
+            <Button asChild size="lg" className="bg-emerald-600 hover:bg-emerald-700 text-white">
+              <Link to="/demo">
+                <Sparkles className="size-4" /> {t('home.tryDemo')}
+              </Link>
+            </Button>
+          </div>
+        )}
       </div>
 
       {/* Feature Showcase + Top Scored Stocks */}

--- a/app/services/demos/data_bundle.rb
+++ b/app/services/demos/data_bundle.rb
@@ -1,0 +1,470 @@
+require "ostruct"
+
+module Demos
+  # Returns a single curated payload that the public `/api/v1/demo` endpoint
+  # serves and the React frontend prefills into React Query under the same
+  # keys the real hooks use (`['radar']`, `['holdings']`, `['dividends']`,
+  # `['dividends', 'chart', ...]`). Anonymous visitors browsing `/demo` then
+  # see realistic data without any DB persistence — nothing here is saved,
+  # so community aggregates (Stocks::CommunityTargetPrice, Most Held, etc.)
+  # are unaffected.
+  #
+  # Stocks are instantiated as unsaved AR objects with a fake `id`, so
+  # `StockDecorator` works without touching the DB.
+  class DataBundle
+    UPCOMING_EX_DIV_DAYS = 5
+
+    def self.call
+      new.call
+    end
+
+    def call
+      stocks = build_stocks
+      holding_records = build_holding_records(stocks)
+      radar_records = build_radar_records(stocks)
+      dividend_records = build_dividend_records(stocks, holding_records)
+
+      {
+        radar: radar_payload(radar_records),
+        holdings: holdings_payload(holding_records),
+        dividends: dividend_records.map { |row| serialize_dividend(row) },
+        # Default chart: 12 months back + 12 forward (24 months). Full chart:
+        # from earliest dividend (~24 months back) + 12 forward (36 months).
+        # Full must have strictly more months than default for the historic
+        # line chart to render on /demo/dividends.
+        chart: chart_payload(dividend_records, holding_records, months_back: 12),
+        chartFull: chart_payload(dividend_records, holding_records, months_back: 24)
+      }
+    end
+
+    private
+
+    # ─── Stocks ─────────────────────────────────────────────────────────────
+
+    def build_stocks
+      [
+        new_stock(id: 9001, symbol: "AAPL", name: "Apple Inc.",
+                  currency: "USD", price: 178.50,
+                  eps: 6.05, pe_ratio: 29.5, dividend: 1.00, dividend_yield: 0.56,
+                  payout_ratio: 16.5, ma_50: 175.20, ma_200: 168.40,
+                  fifty_two_week_high: 199.62, fifty_two_week_low: 164.08,
+                  ex_dividend_date: 30.days.from_now.to_date,
+                  payment_frequency: "quarterly", payment_months: [ 2, 5, 8, 11 ],
+                  sector: "Technology"),
+        new_stock(id: 9002, symbol: "KO", name: "Coca-Cola Company",
+                  currency: "USD", price: 62.50,
+                  eps: 2.50, pe_ratio: 25.0, dividend: 1.94, dividend_yield: 3.10,
+                  payout_ratio: 77.6, ma_50: 61.00, ma_200: 60.20,
+                  fifty_two_week_high: 65.00, fifty_two_week_low: 55.10,
+                  ex_dividend_date: UPCOMING_EX_DIV_DAYS.days.from_now.to_date,
+                  payment_frequency: "quarterly", payment_months: [ 3, 6, 9, 12 ],
+                  sector: "Consumer Defensive"),
+        new_stock(id: 9003, symbol: "JNJ", name: "Johnson & Johnson",
+                  currency: "USD", price: 158.20,
+                  eps: 9.85, pe_ratio: 16.1, dividend: 4.96, dividend_yield: 3.14,
+                  payout_ratio: 50.4, ma_50: 156.00, ma_200: 154.80,
+                  fifty_two_week_high: 175.97, fifty_two_week_low: 143.13,
+                  ex_dividend_date: 50.days.from_now.to_date,
+                  payment_frequency: "quarterly", payment_months: [ 3, 6, 9, 12 ],
+                  sector: "Healthcare"),
+        new_stock(id: 9004, symbol: "O", name: "Realty Income Corporation",
+                  currency: "USD", price: 56.20,
+                  eps: 1.28, pe_ratio: 43.9, dividend: 3.21, dividend_yield: 5.71,
+                  payout_ratio: 250.7, ma_50: 55.80, ma_200: 54.50,
+                  fifty_two_week_high: 64.78, fifty_two_week_low: 50.71,
+                  ex_dividend_date: 12.days.from_now.to_date,
+                  payment_frequency: "monthly", payment_months: (1..12).to_a,
+                  sector: "Real Estate"),
+        # Radar-only:
+        new_stock(id: 9005, symbol: "MSFT", name: "Microsoft Corporation",
+                  currency: "USD", price: 380.00,
+                  eps: 11.05, pe_ratio: 34.4, dividend: 3.00, dividend_yield: 0.79,
+                  payout_ratio: 27.1, ma_50: 372.00, ma_200: 355.00,
+                  fifty_two_week_high: 420.82, fifty_two_week_low: 309.45,
+                  ex_dividend_date: 60.days.from_now.to_date,
+                  payment_frequency: "quarterly", payment_months: [ 3, 6, 9, 12 ],
+                  sector: "Technology"),
+        new_stock(id: 9006, symbol: "PEP", name: "PepsiCo, Inc.",
+                  currency: "USD", price: 172.40,
+                  eps: 7.05, pe_ratio: 24.5, dividend: 5.42, dividend_yield: 3.14,
+                  payout_ratio: 76.9, ma_50: 170.00, ma_200: 168.50,
+                  fifty_two_week_high: 196.95, fifty_two_week_low: 155.83,
+                  ex_dividend_date: 75.days.from_now.to_date,
+                  payment_frequency: "quarterly", payment_months: [ 1, 3, 6, 9 ],
+                  sector: "Consumer Defensive"),
+        new_stock(id: 9007, symbol: "REP.MC", name: "Repsol S.A.",
+                  currency: "EUR", price: 13.45,
+                  eps: 1.20, pe_ratio: 11.2, dividend: 0.90, dividend_yield: 6.69,
+                  payout_ratio: 75.0, ma_50: 13.20, ma_200: 13.80,
+                  fifty_two_week_high: 15.92, fifty_two_week_low: 11.40,
+                  ex_dividend_date: 20.days.from_now.to_date,
+                  payment_frequency: "semi_annual", payment_months: [ 1, 7 ],
+                  sector: "Energy")
+      ]
+    end
+
+    def new_stock(id:, symbol:, name:, **attrs)
+      stock = Stock.new(symbol: symbol, name: name, **attrs)
+      stock.id = id
+      stock
+    end
+
+    # ─── Holdings ───────────────────────────────────────────────────────────
+
+    # Each holding has a current quantity *and* a DCA tranche schedule so the
+    # dividend chart shows a natural upward trend: early payments use the
+    # smaller historical quantity, recent payments use the current quantity.
+    # `tranches` is [months-ago, shares-bought], and the sum equals the
+    # current quantity.
+    def holding_configs
+      {
+        "AAPL"   => { avg_price: 145.00, tranches: [ [ 20, 10 ], [ 6, 15 ] ] },           # → 25
+        "KO"     => { avg_price: 58.00,  tranches: [ [ 22, 40 ], [ 10, 60 ] ] },          # → 100
+        "JNJ"    => { avg_price: 162.50, tranches: [ [ 18, 8 ], [ 4, 12 ] ] },            # → 20
+        "O"      => { avg_price: 58.40,  tranches: [ [ 20, 25 ], [ 12, 25 ], [ 5, 25 ] ] }, # → 75
+        "REP.MC" => { avg_price: 12.10,  tranches: [ [ 15, 80 ], [ 7, 120 ] ] }           # → 200
+      }
+    end
+
+    def build_holding_records(stocks)
+      configs = holding_configs
+      held = stocks.select { |s| configs.key?(s.symbol) }
+
+      held.each_with_index.map do |stock, i|
+        config = configs[stock.symbol]
+        OpenStruct.new(
+          id: 8001 + i,
+          stock: stock,
+          stock_id: stock.id,
+          quantity: config[:tranches].sum { |_m, q| q },
+          average_price: config[:avg_price],
+          tranches: config[:tranches].map { |months, qty| { date: Date.current - months.months, qty: qty } }
+        )
+      end
+    end
+
+    # Quantity owned on the given date — sum of all tranches whose purchase
+    # date is on/before that date.
+    def quantity_at(holding, date)
+      holding.tranches.select { |t| t[:date] <= date }.sum { |t| t[:qty] }
+    end
+
+    def holdings_payload(holding_records)
+      totals = Hash.new { |h, k| h[k] = { value: 0.0, cost: 0.0 } }
+
+      serialized = holding_records.map do |h|
+        market_value = (h.stock.price || 0) * h.quantity
+        cost = h.average_price * h.quantity
+        gain_loss = market_value - cost
+        gain_loss_percent = cost > 0 ? (gain_loss / cost * 100) : 0
+
+        totals[h.stock.currency][:value] += market_value
+        totals[h.stock.currency][:cost] += cost
+
+        {
+          id: h.id,
+          quantity: h.quantity.to_f,
+          averagePrice: h.average_price.to_f,
+          marketValue: market_value.to_f,
+          gainLoss: gain_loss.to_f,
+          gainLossPercent: gain_loss_percent.to_f,
+          stock: serialize_stock(h.stock)
+        }
+      end
+
+      {
+        holdings: serialized,
+        totalsByCurrency: totals_payload(totals),
+        displayTotal: nil, # demo skips FX conversion display
+        portfolioStats: portfolio_stats_payload(holding_records)
+      }
+    end
+
+    def totals_payload(totals)
+      # Coerce to Float — Stock#price is BigDecimal, which JSON serialises as a
+      # string by default, breaking `.toFixed()` on the React side.
+      totals.transform_values do |t|
+        value = t[:value].to_f
+        cost = t[:cost].to_f
+        gl = value - cost
+        gl_pct = cost > 0 ? (gl / cost * 100) : 0.0
+        {
+          value: value.round(2),
+          cost: cost.round(2),
+          gainLoss: gl.round(2),
+          gainLossPercent: gl_pct.round(2)
+        }
+      end
+    end
+
+    def portfolio_stats_payload(holdings)
+      market_total = holdings.sum { |h| (h.stock.price || 0) * h.quantity }.to_f
+
+      by_currency = holdings.group_by { |h| h.stock.currency }.transform_values do |hs|
+        gross = hs.sum { |h| (h.stock.dividend || 0) * h.quantity }.to_f
+        cost = hs.sum { |h| h.average_price * h.quantity }.to_f
+        market = hs.sum { |h| (h.stock.price || 0) * h.quantity }.to_f
+        {
+          yoc: cost > 0 ? (gross / cost * 100).round(2) : 0.0,
+          currentYield: market > 0 ? (gross / market * 100).round(2) : 0.0
+        }
+      end
+
+      sectors = holdings
+        .group_by { |h| h.stock.sector || "Unknown" }
+        .map do |sector, hs|
+          value = hs.sum { |h| (h.stock.price || 0) * h.quantity }.to_f
+          { sector: sector, value: value.round(2), percent: market_total > 0 ? (value / market_total * 100).round(1) : 0.0 }
+        end
+        .sort_by { |s| -s[:value] }
+
+      display = by_currency["USD"] || by_currency.values.first || { yoc: 0.0, currentYield: 0.0 }
+
+      {
+        byCurrency: by_currency,
+        displayCurrency: by_currency.key?("USD") ? "USD" : by_currency.keys.first,
+        displayYoc: display[:yoc],
+        displayCurrentYield: display[:currentYield],
+        sectors: sectors
+      }
+    end
+
+    # ─── Radar ──────────────────────────────────────────────────────────────
+
+    def build_radar_records(stocks)
+      # Mix of below-target (buy signal, e.g. JNJ, MSFT, O, REP.MC) and
+      # above-target (overpriced, e.g. AAPL, KO, PEP) so the radar visibly
+      # surfaces actionable cards.
+      target_prices = {
+        "AAPL" => 160.00, "KO" => 60.00, "JNJ" => 170.00, "O" => 60.00,
+        "MSFT" => 400.00, "PEP" => 165.00, "REP.MC" => 14.50
+      }
+      stocks.map do |stock|
+        OpenStruct.new(stock: stock, target_price: target_prices[stock.symbol])
+      end
+    end
+
+    def radar_payload(radar_records)
+      {
+        id: 7001,
+        stocks: radar_records.map do |rs|
+          stock_json = serialize_stock(rs.stock).merge(
+            targetPrice: rs.target_price,
+            formattedTargetPrice: format_currency(rs.target_price, rs.stock.currency),
+            priceStatusClass: price_status_class(rs.stock.price, rs.target_price),
+            percentageDifference: percentage_difference(rs.stock.price, rs.target_price),
+            aboveTarget: rs.stock.price && rs.target_price && rs.stock.price > rs.target_price,
+            belowTarget: rs.stock.price && rs.target_price && rs.stock.price < rs.target_price,
+            atTarget: rs.stock.price && rs.target_price && rs.stock.price == rs.target_price,
+            targetAnchors: {
+              community: { value: nil, count: 0 }, # below threshold; demo has no community
+              fiftyTwoWeekMidpoint: midpoint(rs.stock),
+              ma200: rs.stock.ma_200&.to_f,
+              ma50: rs.stock.ma_50&.to_f
+            }
+          )
+          stock_json
+        end
+      }
+    end
+
+    def price_status_class(price, target)
+      return "" unless price && target
+      return "text-emerald-600" if price < target
+      return "text-red-600" if price > target
+      "text-muted-foreground"
+    end
+
+    def percentage_difference(price, target)
+      return nil unless price && target && target > 0
+      pct = ((price - target).abs / target * 100).round(2)
+      "#{pct}%"
+    end
+
+    def midpoint(stock)
+      return nil if stock.fifty_two_week_high.blank? || stock.fifty_two_week_low.blank?
+      ((stock.fifty_two_week_high.to_f + stock.fifty_two_week_low.to_f) / 2.0).round(2)
+    end
+
+    # ─── Dividends ──────────────────────────────────────────────────────────
+
+    def build_dividend_records(_stocks, holdings)
+      # ~24 months of historical dividends. Quantity owned at each payment is
+      # derived from the holding's tranches, so early payments naturally have
+      # smaller amounts and the chart trends upward as the investor DCAs in.
+      records = []
+      id = 6000
+      today = Date.current
+
+      holdings.each do |h|
+        stock = h.stock
+        per_year = case stock.payment_frequency
+        when "monthly" then 12
+        when "semi_annual" then 2
+        when "annual" then 1
+        else 4
+        end
+        per_payment = (stock.dividend || 0) / per_year
+        next if per_payment.zero?
+
+        total_payments = per_year * 2 # cover ~24 months back
+        total_payments.times do |i|
+          months_back = (i * 12 / per_year)
+          payment_date = (today - months_back.months).beginning_of_month + 14.days
+          next if payment_date > today
+
+          qty = quantity_at(h, payment_date)
+          next if qty.zero? # no shares yet, no payment
+
+          amount = (per_payment * qty).round(2)
+          id += 1
+          source = i.even? ? "ibkr" : "manual"
+          tax = amount * 0.15
+          records << OpenStruct.new(
+            id: id,
+            stock: stock,
+            date: payment_date,
+            currency: stock.currency,
+            per_share_amount: per_payment.round(4),
+            quantity: qty,
+            amount: amount,
+            withholding_tax: tax.round(2),
+            source: source
+          )
+        end
+      end
+
+      records.sort_by { |r| -r.date.to_time.to_i }
+    end
+
+    def serialize_dividend(d)
+      net = d.amount - d.withholding_tax
+      {
+        id: d.id,
+        stockId: d.stock.id,
+        symbol: d.stock.symbol,
+        name: d.stock.name,
+        date: d.date.iso8601,
+        perShareAmount: d.per_share_amount&.to_f,
+        quantity: d.quantity,
+        amount: d.amount.to_f,
+        currency: d.currency,
+        withholdingTax: d.withholding_tax.to_f,
+        netAmount: net.to_f,
+        source: d.source
+      }
+    end
+
+    # ─── Chart data ─────────────────────────────────────────────────────────
+
+    def chart_payload(dividends, holding_records, months_back:, months_forward: 12)
+      current_month_start = Date.current.beginning_of_month
+      start_month = current_month_start - months_back.months
+      months = (0..(months_back + months_forward - 1)).map do |i|
+        (start_month + i.months).strftime("%Y-%m")
+      end
+
+      currencies = (dividends.map(&:currency) + holding_records.map { |h| h.stock.currency }).uniq
+      projections = projected_monthly_totals(holding_records, months, current_month_start)
+
+      by_currency = {}
+      currencies.each do |ccy|
+        by_currency[ccy] = months.map do |month|
+          month_start = Date.parse("#{month}-01")
+          is_past = month_start <= current_month_start
+          actual_total = dividends.select { |d| d.currency == ccy && d.date.strftime("%Y-%m") == month }
+                                  .sum(&:amount).to_f.round(2)
+          projected = projections.dig(ccy, month)&.round(2)
+          {
+            month: month,
+            actual: actual_total > 0 ? actual_total : nil,
+            projected: is_past ? nil : (projected || 0.0)
+          }
+        end
+      end
+
+      { byCurrency: by_currency, months: months }
+    end
+
+    # For every future month in the window, project per-stock payments using
+    # the holding's current quantity and the stock's `payment_months` (which
+    # months of the year it pays). Past months get nil projections.
+    def projected_monthly_totals(holdings, months, current_month_start)
+      totals = Hash.new { |h, k| h[k] = Hash.new(0.0) }
+
+      holdings.each do |h|
+        stock = h.stock
+        per_year = case stock.payment_frequency
+        when "monthly" then 12
+        when "semi_annual" then 2
+        when "annual" then 1
+        else 4
+        end
+        per_payment = (stock.dividend || 0) / per_year
+        next unless per_payment.positive?
+        next if stock.payment_months.blank?
+
+        income_per_payment = (per_payment * h.quantity).to_f
+        currency = stock.currency
+
+        months.each do |month_key|
+          month_start = Date.parse("#{month_key}-01")
+          next if month_start <= current_month_start # only future
+          totals[currency][month_key] += income_per_payment if stock.payment_months.include?(month_start.month)
+        end
+      end
+
+      totals
+    end
+
+    # ─── Shared serializer ──────────────────────────────────────────────────
+
+    def serialize_stock(stock)
+      decorated = StockDecorator.new(stock)
+      {
+        id: stock.id,
+        symbol: stock.symbol,
+        name: stock.name,
+        currency: stock.currency,
+        price: stock.price,
+        formattedPrice: decorated.formatted_price,
+        eps: stock.eps,
+        peRatio: stock.pe_ratio,
+        dividend: stock.dividend,
+        dividendYield: stock.dividend_yield,
+        payoutRatio: stock.payout_ratio,
+        ma50: stock.ma_50,
+        ma200: stock.ma_200,
+        formattedEps: decorated.formatted_eps,
+        formattedPeRatio: decorated.formatted_pe_ratio,
+        formattedDividend: decorated.formatted_dividend,
+        formattedDividendYield: decorated.formatted_dividend_yield,
+        formattedPayoutRatio: decorated.formatted_payout_ratio,
+        formattedMa50: decorated.formatted_ma_50,
+        formattedMa200: decorated.formatted_ma_200,
+        exDividendDate: stock.ex_dividend_date&.iso8601,
+        paymentFrequency: stock.payment_frequency,
+        paymentMonths: decorated.payment_months,
+        shiftedPaymentMonths: decorated.shifted_payment_months,
+        dividendPerPayment: decorated.dividend_per_payment,
+        formattedDividendPerPayment: decorated.formatted_dividend_per_payment,
+        formattedPaymentFrequency: decorated.formatted_payment_frequency,
+        formattedExDividendDate: decorated.formatted_ex_dividend_date,
+        dividendScheduleAvailable: decorated.dividend_schedule_available?,
+        dividendScore: decorated.dividend_score,
+        dividendScoreLabel: decorated.dividend_score_label,
+        fiftyTwoWeekHigh: stock.fifty_two_week_high,
+        fiftyTwoWeekLow: stock.fifty_two_week_low,
+        formattedFiftyTwoWeekHigh: decorated.formatted_fifty_two_week_high,
+        formattedFiftyTwoWeekLow: decorated.formatted_fifty_two_week_low,
+        fiftyTwoWeekRangePosition: decorated.fifty_two_week_range_position,
+        fiftyTwoWeekDataAvailable: decorated.fifty_two_week_data_available?
+      }
+    end
+
+    def format_currency(amount, currency)
+      symbol = Stock::CURRENCY_SYMBOLS[currency] || "#{currency} "
+      "#{symbol}#{format('%.2f', amount.to_f)}"
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,9 @@ Rails.application.routes.draw do
   # Versioned namespace allows future API changes without breaking existing clients
   namespace :api do
     namespace :v1 do
+      # Public anonymous-access endpoints (no auth required)
+      resource :demo, only: [ :show ], controller: "demos"
+
       # Stock endpoints - public (no auth required for browsing)
       resources :stocks, only: [ :index, :show ] do
         member do

--- a/spec/requests/api/v1/demos_spec.rb
+++ b/spec/requests/api/v1/demos_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::Demos", type: :request do
+  describe "GET /api/v1/demo" do
+    it "responds with 200 even when unauthenticated" do
+      get "/api/v1/demo"
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "returns the radar / holdings / dividends / chart sections" do
+      get "/api/v1/demo"
+      data = JSON.parse(response.body)["data"]
+      expect(data.keys).to contain_exactly("radar", "holdings", "dividends", "chart", "chartFull")
+    end
+
+    it "ships a non-empty radar with target anchors per stock" do
+      get "/api/v1/demo"
+      stocks = JSON.parse(response.body)["data"]["radar"]["stocks"]
+      expect(stocks).not_to be_empty
+      expect(stocks.first.keys).to include("symbol", "name", "currency", "price", "targetPrice", "targetAnchors")
+      expect(stocks.first["targetAnchors"].keys).to contain_exactly("community", "fiftyTwoWeekMidpoint", "ma200", "ma50")
+    end
+
+    it "ships holdings with portfolio stats + per-currency totals" do
+      get "/api/v1/demo"
+      payload = JSON.parse(response.body)["data"]["holdings"]
+      expect(payload["holdings"]).not_to be_empty
+      expect(payload["totalsByCurrency"]).to have_key("USD")
+      expect(payload["portfolioStats"]).to include("displayYoc", "displayCurrentYield", "sectors")
+    end
+
+    it "ships dividends with both manual and ibkr sources for visual variety" do
+      get "/api/v1/demo"
+      dividends = JSON.parse(response.body)["data"]["dividends"]
+      sources = dividends.map { |d| d["source"] }.uniq
+      expect(sources).to include("manual", "ibkr")
+    end
+
+    it "writes nothing to the database" do
+      expect {
+        get "/api/v1/demo"
+      }.not_to change { [ Stock.count, Holding.count, RadarStock.count, Dividend.count, User.count ] }
+    end
+  end
+end

--- a/spec/services/demos/data_bundle_spec.rb
+++ b/spec/services/demos/data_bundle_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+RSpec.describe Demos::DataBundle, type: :service do
+  subject(:bundle) { described_class.call }
+
+  describe "radar" do
+    it "ships a mix of below-target and above-target stocks so the radar surfaces actionable cards" do
+      stocks = bundle[:radar][:stocks]
+      expect(stocks.any? { |s| s[:belowTarget] }).to be(true), "expected at least one below-target stock"
+      expect(stocks.any? { |s| s[:aboveTarget] }).to be(true), "expected at least one above-target stock"
+    end
+  end
+
+  describe "holdings" do
+    it "includes a EUR-denominated position (REP.MC) so the dividend chart shows multiple currencies" do
+      holdings = bundle[:holdings][:holdings]
+      currencies = holdings.map { |h| h[:stock][:currency] }
+      expect(currencies).to include("USD", "EUR")
+      expect(holdings.any? { |h| h[:stock][:symbol] == "REP.MC" }).to be(true)
+    end
+
+    it "computes per-currency yield/cost totals for every currency held" do
+      stats = bundle[:holdings][:portfolioStats]
+      expect(stats[:byCurrency].keys).to include("USD", "EUR")
+      stats[:byCurrency].each_value do |totals|
+        expect(totals).to include(:yoc, :currentYield)
+      end
+    end
+  end
+
+  describe "dividend growth via DCA tranches" do
+    it "produces smaller historical amounts than recent amounts for the same stock" do
+      # KO accumulates from 40 shares (22mo ago) → 100 shares (10mo ago). Its
+      # oldest dividend should be ~40% the size of its most recent one.
+      ko_dividends = bundle[:dividends].select { |d| d[:symbol] == "KO" }.sort_by { |d| d[:date] }
+      expect(ko_dividends.length).to be >= 2
+      expect(ko_dividends.first[:amount]).to be < ko_dividends.last[:amount]
+    end
+  end
+
+  describe "chart projections" do
+    it "fills future months with a projected number and leaves past months nil" do
+      buckets = bundle[:chart][:byCurrency]["USD"]
+      current_month = Date.current.strftime("%Y-%m")
+
+      past = buckets.select { |b| b[:month] < current_month }
+      future = buckets.select { |b| b[:month] > current_month }
+
+      expect(past).not_to be_empty
+      expect(future).not_to be_empty
+      expect(past.map { |b| b[:projected] }.uniq).to eq([ nil ])
+      expect(future.any? { |b| b[:projected].is_a?(Numeric) && b[:projected] > 0 }).to be(true)
+    end
+
+    it "ships chartFull spanning strictly more months than the default chart" do
+      expect(bundle[:chartFull][:months].length).to be > bundle[:chart][:months].length
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Lets logged-out visitors explore a realistic populated radar, portfolio, and dividends page at `/demo/*` without creating an account. Read-only navigation works; every write action (add to radar, edit target, log/import dividend, edit profile, etc.) opens a contextual *Sign up to make this yours* modal so we convert at peak intent rather than at the front door.
- One public endpoint (`GET /api/v1/demo`) returns a curated bundle shaped exactly like the corresponding controllers — `Demos::DataBundle` builds it from in-memory unsaved AR instances, so community aggregates (`Stocks::CommunityTargetPrice`, Most Held, Pulse, etc.) and DB tables are untouched.
- `/demo/*` prefills the React Query cache under the same keys the real hooks read from, so `RadarPage`, `PortfolioPage`, and `DividendsPage` are reused as-is. `useDemoGuardedMutation` wraps every write hook to short-circuit and open the nudge. Logged-in users hitting `/demo` get redirected to their real portfolio.
- Realistic data: 6 stocks including **REP.MC** for EUR dividends, DCA tranches across 24 months so the dividend chart trends upward, future months projected via each stock's payment schedule, and a radar mix of above/below target cards. Color palette is emerald to avoid clashing with Pulse's purple.
- i18n in both en + es. Hero CTA on `HomePage` ("Try a sample portfolio") for logged-out users only.

## Test plan
- [x] `bundle exec rspec spec/services/demos spec/requests/api/v1/demos_spec.rb` — green (12 examples)
- [x] `bundle exec rspec` — full suite green (582 examples)
- [x] `bin/rubocop` on touched Ruby — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx vite build` — succeeds
- [ ] Manual (logged out): `/` → "Try a sample portfolio" → `/demo/portfolio` shows banner + populated USD+EUR data; check `/demo/radar` (mix of above/below target), `/demo/dividends` (historic chart + projected future months).
- [ ] Manual: click "Add to radar" / edit target / log dividend → contextual nudge opens; "Sign up" → `/signup`.
- [ ] Manual (logged in): visit `/demo` → redirected to `/portfolio`.
- [ ] Manual: switch language to ES → banner + nudge copy reads naturally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)