### PR TITLE
Rate-limit AI to 3/day per user + provider-agnostic abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,29 @@ GEMINI_API_KEY=your_gemini_api_key
 
 Without this key, the app works normally but AI insight features will be unavailable.
 
+#### Switching AI providers
+
+The AI layer is provider-agnostic. Gemini is the only implementation today,
+but adding another (Anthropic, OpenAI, etc.) is a 1-day task:
+
+1. Add `app/services/ai_providers/<name>_provider.rb` inheriting from
+   `AiProviders::BaseProvider` and implementing `name`, `radar_insights`,
+   `portfolio_insights`, `stock_summary`, and `social_post`.
+2. Set the provider via the `AI_PROVIDER` env var (e.g. `AI_PROVIDER=anthropic`).
+   Default is `gemini`.
+
+All AI-using code paths go through `AiProviders.current` — never instantiate
+a specific provider class directly.
+
+#### AI usage limits
+
+Non-admin users are capped at **3 AI requests per day** (UTC). Cache hits don't
+count — only actual LLM calls consume quota. The limit applies across every
+AI surface (radar insights, portfolio insights, stock summaries) and is logged
+per user / feature / provider on the `ai_requests` table for cost attribution.
+Admins bypass the limit. To change the cap, edit
+`AiRateLimiter::DAILY_LIMIT`.
+
 ### 6. Install dependencies:
 
     ```

--- a/app/controllers/api/v1/admin/content_drafts_controller.rb
+++ b/app/controllers/api/v1/admin/content_drafts_controller.rb
@@ -20,7 +20,8 @@ module Api
           payload = ContentGenerator.call(
             category: topic[:category],
             topic_key: topic[:topic_key],
-            inputs: inputs
+            inputs: inputs,
+            user: Current.user
           )
 
           draft = ContentDraft.create!(

--- a/app/controllers/api/v1/holdings_controller.rb
+++ b/app/controllers/api/v1/holdings_controller.rb
@@ -95,7 +95,7 @@ module Api
       def insights
         holdings = Current.user.holdings.includes(:stock)
         stocks_data = holdings.map { |h| serialize_stock_for_ai(h.stock) }
-        result = AiInsightsService.portfolio_insights(stocks_data, locale: params[:locale], preferred_currency: Current.user.preferred_currency)
+        result = AiInsightsService.portfolio_insights(stocks_data, user: Current.user, locale: params[:locale], preferred_currency: Current.user.preferred_currency)
         render_success(result)
       rescue AiProviders::BaseProvider::AiError => e
         Rails.logger.error "AI portfolio insights error: #{e.message}"

--- a/app/controllers/api/v1/radars_controller.rb
+++ b/app/controllers/api/v1/radars_controller.rb
@@ -46,7 +46,7 @@ module Api
       def insights
         stocks = @radar.sorted_stocks || []
         stocks_data = stocks.map { |s| serialize_stock_for_ai(s) }
-        result = AiInsightsService.radar_insights(stocks_data, locale: params[:locale], preferred_currency: Current.user.preferred_currency)
+        result = AiInsightsService.radar_insights(stocks_data, user: Current.user, locale: params[:locale], preferred_currency: Current.user.preferred_currency)
         render_success(result)
       rescue AiProviders::BaseProvider::AiError => e
         Rails.logger.error "AI insights error: #{e.message}"

--- a/app/controllers/api/v1/stocks_controller.rb
+++ b/app/controllers/api/v1/stocks_controller.rb
@@ -83,7 +83,7 @@ module Api
           updated_at: stock.updated_at.to_i
         }
 
-        result = AiInsightsService.stock_summary(stock_data, locale: params[:locale], preferred_currency: Current.user.preferred_currency)
+        result = AiInsightsService.stock_summary(stock_data, user: Current.user, locale: params[:locale], preferred_currency: Current.user.preferred_currency)
         render_success(result)
       rescue AiProviders::BaseProvider::AiError => e
         Rails.logger.error "AI summary error for stock #{params[:id]}: #{e.message}"

--- a/app/frontend/components/AiRateLimitedNotice.tsx
+++ b/app/frontend/components/AiRateLimitedNotice.tsx
@@ -1,0 +1,20 @@
+import { Sparkles } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+
+// Soft inline notice rendered by AI insight cards when the user has used their
+// daily LLM quota. Honest about the *why* (it costs money) without making it
+// feel punitive.
+export function AiRateLimitedNotice({ limit }: { limit?: number }) {
+  const { t } = useTranslation()
+  return (
+    <div className="rounded-lg border border-amber-200 dark:border-amber-900/40 bg-amber-50/60 dark:bg-amber-950/20 p-4">
+      <p className="text-sm font-medium text-foreground flex items-center gap-2 mb-1">
+        <Sparkles className="size-4 text-amber-500 shrink-0" />
+        {t('ai.rateLimited.title')}
+      </p>
+      <p className="text-sm text-muted-foreground">
+        {t('ai.rateLimited.body', { limit: limit ?? 3 })}
+      </p>
+    </div>
+  )
+}

--- a/app/frontend/components/PortfolioInsights.tsx
+++ b/app/frontend/components/PortfolioInsights.tsx
@@ -10,6 +10,8 @@ import {
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { usePortfolioInsights } from '../hooks/useAiInsights'
+import { isAiRateLimited } from '../types'
+import { AiRateLimitedNotice } from './AiRateLimitedNotice'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -74,7 +76,11 @@ export function PortfolioInsights({ hasStocks }: PortfolioInsightsProps) {
             </div>
           )}
 
-          {data && !isLoading && (
+          {data && !isLoading && isAiRateLimited(data) && (
+            <AiRateLimitedNotice limit={data.limit} />
+          )}
+
+          {data && !isLoading && !isAiRateLimited(data) && (
             <div className="space-y-4">
               <div className="rounded-lg bg-violet-50 dark:bg-violet-950/30 p-4">
                 <p className="text-sm text-foreground">{data.summary}</p>

--- a/app/frontend/components/RadarInsights.tsx
+++ b/app/frontend/components/RadarInsights.tsx
@@ -10,6 +10,8 @@ import {
 } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useRadarInsights } from '../hooks/useAiInsights'
+import { isAiRateLimited } from '../types'
+import { AiRateLimitedNotice } from './AiRateLimitedNotice'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -74,7 +76,11 @@ export function RadarInsights({ hasStocks }: RadarInsightsProps) {
             </div>
           )}
 
-          {data && !isLoading && (
+          {data && !isLoading && isAiRateLimited(data) && (
+            <AiRateLimitedNotice limit={data.limit} />
+          )}
+
+          {data && !isLoading && !isAiRateLimited(data) && (
             <div className="space-y-4">
               {/* Summary */}
               <div className="rounded-lg bg-violet-50 dark:bg-violet-950/30 p-4">

--- a/app/frontend/components/StockAiSummary.tsx
+++ b/app/frontend/components/StockAiSummary.tsx
@@ -6,7 +6,8 @@ import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
 import { Skeleton } from '@/components/ui/skeleton'
-import type { StockAiSummary as StockAiSummaryType } from '../types'
+import { isAiRateLimited, type StockAiSummary as StockAiSummaryType } from '../types'
+import { AiRateLimitedNotice } from './AiRateLimitedNotice'
 
 interface StockAiSummaryProps {
   stockId: number
@@ -65,7 +66,11 @@ export function StockAiSummary({ stockId }: StockAiSummaryProps) {
             </div>
           )}
 
-          {data && !isLoading && (
+          {data && !isLoading && isAiRateLimited(data) && (
+            <AiRateLimitedNotice limit={data.limit} />
+          )}
+
+          {data && !isLoading && !isAiRateLimited(data) && (
             <div className="space-y-2">
               <div className="flex items-center gap-2">
                 <Badge variant={verdictVariant[data.verdict]}>

--- a/app/frontend/lib/api.ts
+++ b/app/frontend/lib/api.ts
@@ -13,7 +13,7 @@
  * This prevents malicious sites from making requests on behalf of the user.
  */
 
-import type { Stock, StockSearchResult, RadarStock, User, BuyPlanResponse, AdminDashboardStats, AdminUser, RadarInsights, StockAiSummary, HoldingsResponse, Holding, UserProfile } from '../types'
+import type { Stock, StockSearchResult, RadarStock, User, BuyPlanResponse, AdminDashboardStats, AdminUser, RadarInsightsResult, StockAiSummaryResult, HoldingsResponse, Holding, UserProfile } from '../types'
 
 const API_BASE = '/api/v1'
 
@@ -126,7 +126,7 @@ export const stocksApi = {
   /**
    * Get AI-generated summary for a stock (authenticated)
    */
-  getAiSummary: (id: number, locale?: string) => apiFetch<StockAiSummary>(`/stocks/${id}/ai_summary${locale ? `?locale=${locale}` : ''}`),
+  getAiSummary: (id: number, locale?: string) => apiFetch<StockAiSummaryResult>(`/stocks/${id}/ai_summary${locale ? `?locale=${locale}` : ''}`),
 }
 
 // ============================================================================
@@ -188,7 +188,7 @@ export const radarApi = {
   /**
    * Get AI-generated insights for the radar portfolio (authenticated)
    */
-  getInsights: (locale?: string) => apiFetch<RadarInsights>(`/radar/insights${locale ? `?locale=${locale}` : ''}`),
+  getInsights: (locale?: string) => apiFetch<RadarInsightsResult>(`/radar/insights${locale ? `?locale=${locale}` : ''}`),
 }
 
 // ============================================================================
@@ -285,7 +285,7 @@ export const holdingsApi = {
       method: 'DELETE',
     }),
 
-  getInsights: (locale?: string) => apiFetch<RadarInsights>(`/holdings/insights${locale ? `?locale=${locale}` : ''}`),
+  getInsights: (locale?: string) => apiFetch<RadarInsightsResult>(`/holdings/insights${locale ? `?locale=${locale}` : ''}`),
 
   importFromCart: (items: { stock_id: number; quantity: number }[]) =>
     apiFetch<{ imported: number }>('/holdings/import_from_cart', {

--- a/app/frontend/locales/en.ts
+++ b/app/frontend/locales/en.ts
@@ -494,6 +494,14 @@ const en = {
     caution: 'Caution',
     avoid: 'Avoid',
   },
+
+  // AI rate-limit notice (shown when a user hits their daily AI quota)
+  ai: {
+    rateLimited: {
+      title: 'Daily AI limit reached',
+      body: "You've used your {{limit}} free AI requests today. AI calls cost real money \u2014 we're offering them free for now. Try again tomorrow.",
+    },
+  },
 } as const
 
 export default en

--- a/app/frontend/locales/es.ts
+++ b/app/frontend/locales/es.ts
@@ -493,6 +493,14 @@ const es = {
     caution: 'Precaución',
     avoid: 'Evitar',
   },
+
+  // AI rate-limit notice (shown when a user hits their daily AI quota)
+  ai: {
+    rateLimited: {
+      title: 'Límite diario de IA alcanzado',
+      body: 'Has usado tus {{limit}} solicitudes gratuitas de IA hoy. Las llamadas a la IA cuestan dinero real — las ofrecemos gratis por ahora. Inténtalo de nuevo mañana.',
+    },
+  },
 } as const
 
 export default es

--- a/app/frontend/types/index.ts
+++ b/app/frontend/types/index.ts
@@ -275,6 +275,28 @@ export interface RadarInsights {
 }
 
 /**
+ * AI Rate-Limit response — returned by any AiInsightsService endpoint when
+ * the caller has used their daily AI quota. Frontend components check for
+ * `rateLimited === true` and render a friendly notice instead of the data.
+ */
+export interface AiRateLimited {
+  rateLimited: true
+  feature: string
+  limit: number
+  remaining: number
+  resetAt: string
+}
+
+export type RadarInsightsResult = RadarInsights | AiRateLimited
+export type StockAiSummaryResult = StockAiSummary | AiRateLimited
+
+export function isAiRateLimited(
+  result: unknown,
+): result is AiRateLimited {
+  return typeof result === 'object' && result !== null && (result as { rateLimited?: boolean }).rateLimited === true
+}
+
+/**
  * AI Stock Summary
  * Mirrors: AiInsightsService.stock_summary response
  */

--- a/app/models/ai_request.rb
+++ b/app/models/ai_request.rb
@@ -1,0 +1,24 @@
+# Log of actual LLM calls (cache hits are *not* recorded). Powers the per-user
+# daily rate limit (`AiRateLimiter`) and gives us a paper trail for cost
+# attribution per user / feature / provider.
+class AiRequest < ApplicationRecord
+  belongs_to :user
+
+  # Feature keys must match the ones AiRateLimiter / AiInsightsService pass in.
+  # Adding a new AI-using feature? Register its key here so the values stay
+  # discoverable from one place.
+  FEATURES = %w[
+    radar_insights
+    portfolio_insights
+    stock_summary
+    social_post
+    telegram_chat
+  ].freeze
+
+  validates :feature, inclusion: { in: FEATURES }
+  validates :provider, presence: true
+
+  scope :today_for, ->(user) {
+    where(user: user).where("created_at >= ?", Time.current.utc.beginning_of_day)
+  }
+end

--- a/app/services/ai_insights_service.rb
+++ b/app/services/ai_insights_service.rb
@@ -1,25 +1,139 @@
+# Facade in front of the configured `AiProviders.current`. Handles three
+# cross-cutting concerns the providers don't (and shouldn't) know about:
+#
+#   1. **Caching** — identical inputs return the cached payload for 6h. Cache
+#      hits never count against the user's rate limit.
+#   2. **Rate limiting** — non-admin users are capped per day by `AiRateLimiter`.
+#      When the limit is hit, we return a `{ rateLimited: true, ... }` payload
+#      that the frontend renders as a friendly notice.
+#   3. **Cost logging** — every actual LLM hit creates an `AiRequest` row
+#      (user / feature / provider) for the limiter and future cost analytics.
 class AiInsightsService
+  RATE_LIMITED = :rate_limited
+
   class << self
-    def radar_insights(stocks_data, locale: nil, preferred_currency: nil)
-      provider.radar_insights(stocks_data, locale: locale, preferred_currency: preferred_currency)
+    def radar_insights(stocks_data, user:, locale: nil, preferred_currency: nil)
+      return empty_radar_insights if stocks_data.blank?
+
+      lang = normalize_locale(locale)
+      ccy = preferred_currency || "USD"
+      cache_key = "ai/radar/#{Digest::MD5.hexdigest(stocks_data.to_json)}/#{lang}/#{ccy}"
+
+      with_cache_and_limit(cache_key: cache_key, user: user, feature: "radar_insights") do
+        provider.radar_insights(stocks_data, locale: lang, preferred_currency: ccy)
+      end
     end
 
-    def portfolio_insights(stocks_data, locale: nil, preferred_currency: nil)
-      provider.portfolio_insights(stocks_data, locale: locale, preferred_currency: preferred_currency)
+    def portfolio_insights(stocks_data, user:, locale: nil, preferred_currency: nil)
+      return empty_portfolio_insights if stocks_data.blank?
+
+      lang = normalize_locale(locale)
+      ccy = preferred_currency || "USD"
+      cache_key = "ai/portfolio/#{Digest::MD5.hexdigest(stocks_data.to_json)}/#{lang}/#{ccy}"
+
+      with_cache_and_limit(cache_key: cache_key, user: user, feature: "portfolio_insights") do
+        provider.portfolio_insights(stocks_data, locale: lang, preferred_currency: ccy)
+      end
     end
 
-    def stock_summary(stock_data, locale: nil, preferred_currency: nil)
-      provider.stock_summary(stock_data, locale: locale, preferred_currency: preferred_currency)
+    def stock_summary(stock_data, user:, locale: nil, preferred_currency: nil)
+      return empty_stock_summary if stock_data.blank?
+
+      lang = normalize_locale(locale)
+      ccy = preferred_currency || "USD"
+      cache_key = "ai/stock/#{stock_data[:id]}/#{stock_data[:updated_at]}/#{lang}/#{ccy}"
+
+      with_cache_and_limit(cache_key: cache_key, user: user, feature: "stock_summary") do
+        provider.stock_summary(stock_data, locale: lang, preferred_currency: ccy)
+      end
     end
 
-    def social_post(topic, locale: nil)
-      provider.social_post(topic, locale: locale)
+    # `user:` is the operator who triggered the draft (always an admin via
+    # `Admin::ContentDraftsController`). Pass through so the limiter sees an
+    # admin and bypasses; the record still gets logged for cost attribution.
+    def social_post(topic, user:, locale: nil)
+      lang = normalize_locale(locale)
+      # No cache: each click should produce a fresh draft.
+      with_limit_only(user: user, feature: "social_post") do
+        provider.social_post(topic, locale: lang)
+      end
     end
 
     private
 
     def provider
-      @provider ||= AiProviders::GeminiProvider.new
+      AiProviders.current
+    end
+
+    SUPPORTED_LOCALES = %w[en es].freeze
+
+    def normalize_locale(locale)
+      lang = locale.to_s.split("-").first&.downcase
+      SUPPORTED_LOCALES.include?(lang) ? lang : "en"
+    end
+
+    # Cache probe → limit check → LLM call → log → cache write. Crucially the
+    # cache probe runs *before* the limit check, so a rate-limited user can
+    # still get cached data — only fresh LLM hits are blocked.
+    def with_cache_and_limit(cache_key:, user:, feature:)
+      if (cached = Rails.cache.read(cache_key))
+        return cached
+      end
+
+      gate = AiRateLimiter.allow?(user, feature)
+      return rate_limited_payload(feature, gate) unless gate.allowed?
+
+      data = yield
+      AiRateLimiter.record!(user: user, feature: feature, provider: provider.name)
+      Rails.cache.write(cache_key, data, expires_in: 6.hours)
+      data
+    end
+
+    def with_limit_only(user:, feature:)
+      gate = AiRateLimiter.allow?(user, feature)
+      return rate_limited_payload(feature, gate) unless gate.allowed?
+
+      data = yield
+      AiRateLimiter.record!(user: user, feature: feature, provider: provider.name)
+      data
+    end
+
+    def rate_limited_payload(feature, gate)
+      {
+        rateLimited: true,
+        feature: feature,
+        limit: gate.limit,
+        remaining: gate.remaining,
+        resetAt: gate.reset_at&.iso8601
+      }
+    end
+
+    def empty_radar_insights
+      {
+        summary: "Add stocks to your radar to get AI-powered portfolio insights.",
+        buyingOpportunities: [],
+        coverageGaps: "No stocks to analyze.",
+        riskFlags: [],
+        strengths: []
+      }
+    end
+
+    def empty_portfolio_insights
+      {
+        summary: "Add stocks to your portfolio to get AI-powered insights.",
+        buyingOpportunities: [],
+        coverageGaps: "No stocks to analyze.",
+        riskFlags: [],
+        strengths: []
+      }
+    end
+
+    def empty_stock_summary
+      {
+        summary: "No data available for analysis.",
+        verdict: "hold",
+        keyPoints: []
+      }
     end
   end
 end

--- a/app/services/ai_providers.rb
+++ b/app/services/ai_providers.rb
@@ -1,0 +1,26 @@
+module AiProviders
+  # Factory that returns the configured AI provider instance, memoised per
+  # process. Selection follows `Rails.application.config.ai_provider`
+  # (set by `config/initializers/ai_provider.rb`, overridable via
+  # `ENV["AI_PROVIDER"]`).
+  #
+  # All AI-using code paths in the app should go through this — never
+  # instantiate a specific provider class directly. Swapping Gemini for
+  # Anthropic/OpenAI should be a 1-day task (add a provider that conforms
+  # to `AiProviders::BaseProvider`, flip the env var), not a refactor.
+  def self.current
+    @current ||= begin
+      name = Rails.application.config.ai_provider
+      "AiProviders::#{name.to_s.classify}Provider".constantize.new
+    rescue NameError => e
+      raise "Unknown AI provider: #{name.inspect}. " \
+            "Add a class under AiProviders:: that inherits from BaseProvider. " \
+            "(#{e.message})"
+    end
+  end
+
+  # Test/spec hook — reset the memoised instance.
+  def self.reset!
+    @current = nil
+  end
+end

--- a/app/services/ai_providers/base_provider.rb
+++ b/app/services/ai_providers/base_provider.rb
@@ -2,6 +2,12 @@ module AiProviders
   class BaseProvider
     class AiError < StandardError; end
 
+    # Short identifier used for logging / analytics (e.g. on AiRequest rows).
+    # Each subclass must override.
+    def name
+      raise NotImplementedError, "Subclasses must implement #name"
+    end
+
     # Generate insights for a radar's stock portfolio
     #
     # @param stocks_data [Array<Hash>] array of stock data hashes

--- a/app/services/ai_providers/gemini_provider.rb
+++ b/app/services/ai_providers/gemini_provider.rb
@@ -39,15 +39,10 @@ module AiProviders
     # Generate a social-media post for X and LinkedIn from a content topic.
     # Topic shape: { category:, topic_key:, inputs: {…} }. No caching: every
     # button click should produce a fresh draft, not return a stale one.
-    # max_output_tokens needs comfortable headroom because the LinkedIn body
-    # (≤1500 chars) plus X text plus headline plus JSON schema overhead can
-    # spike past lower limits when Gemini's sampling lands on a wordy response
-    # — hitting it caused intermittent "response not valid JSON (truncated)"
-    # errors. 4096 is well within Flash's 8192 cap and leaves slack.
     def social_post(topic, locale: nil)
       lang = normalized_locale(locale)
       prompt = build_social_post_prompt(topic, lang)
-      response = call_gemini(prompt, social_post_response_schema, max_output_tokens: 4096)
+      response = call_gemini(prompt, social_post_response_schema)
       parse_response(response)
     end
 
@@ -70,7 +65,11 @@ module AiProviders
       ENV["GEMINI_API_KEY"]
     end
 
-    def call_gemini(prompt, schema, max_output_tokens: 1024)
+    # 4096 is well within Flash's 8192 cap and leaves slack for Gemini 2.5's
+    # "thinking" tokens, which silently consume the output budget before the
+    # actual response — at 1024 we hit intermittent "response not valid JSON
+    # (truncated)" errors even for short outputs like stock summaries.
+    def call_gemini(prompt, schema, max_output_tokens: 4096)
       raise AiError, "GEMINI_API_KEY is not configured" if api_key.blank?
 
       uri = URI("#{GEMINI_API_URL}?key=#{api_key}")

--- a/app/services/ai_providers/gemini_provider.rb
+++ b/app/services/ai_providers/gemini_provider.rb
@@ -2,34 +2,28 @@ module AiProviders
   class GeminiProvider < BaseProvider
     GEMINI_API_URL = "https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent".freeze
 
+    def name
+      :gemini
+    end
+
     def radar_insights(stocks_data, locale: nil, preferred_currency: nil)
       return empty_radar_insights if stocks_data.blank?
 
-      fingerprint = Digest::MD5.hexdigest(stocks_data.to_json)
       lang = normalized_locale(locale)
       ccy = preferred_currency || "USD"
-      cache_key = "ai/radar/#{fingerprint}/#{lang}/#{ccy}"
-
-      cache_fetch(cache_key) do
-        prompt = build_radar_prompt(stocks_data, lang, ccy)
-        response = call_gemini(prompt, radar_response_schema)
-        parse_response(response)
-      end
+      prompt = build_radar_prompt(stocks_data, lang, ccy)
+      response = call_gemini(prompt, radar_response_schema)
+      parse_response(response)
     end
 
     def portfolio_insights(stocks_data, locale: nil, preferred_currency: nil)
       return empty_portfolio_insights if stocks_data.blank?
 
-      fingerprint = Digest::MD5.hexdigest(stocks_data.to_json)
       lang = normalized_locale(locale)
       ccy = preferred_currency || "USD"
-      cache_key = "ai/portfolio/#{fingerprint}/#{lang}/#{ccy}"
-
-      cache_fetch(cache_key) do
-        prompt = build_portfolio_prompt(stocks_data, lang, ccy)
-        response = call_gemini(prompt, radar_response_schema)
-        parse_response(response)
-      end
+      prompt = build_portfolio_prompt(stocks_data, lang, ccy)
+      response = call_gemini(prompt, radar_response_schema)
+      parse_response(response)
     end
 
     def stock_summary(stock_data, locale: nil, preferred_currency: nil)
@@ -37,13 +31,9 @@ module AiProviders
 
       lang = normalized_locale(locale)
       ccy = preferred_currency || "USD"
-      cache_key = "ai/stock/#{stock_data[:id]}/#{stock_data[:updated_at]}/#{lang}/#{ccy}"
-
-      cache_fetch(cache_key) do
-        prompt = build_stock_prompt(stock_data, lang, ccy)
-        response = call_gemini(prompt, stock_response_schema)
-        parse_response(response)
-      end
+      prompt = build_stock_prompt(stock_data, lang, ccy)
+      response = call_gemini(prompt, stock_response_schema)
+      parse_response(response)
     end
 
     # Generate a social-media post for X and LinkedIn from a content topic.

--- a/app/services/ai_rate_limiter.rb
+++ b/app/services/ai_rate_limiter.rb
@@ -1,0 +1,33 @@
+# Per-user daily limit on AI calls (calendar day in UTC). AI inference costs
+# real money and a power user refreshing insights could spike the bill — this
+# caps non-admin users at `DAILY_LIMIT` LLM hits per day across every AI-using
+# surface (web insights, future Telegram bot, etc.). Admin accounts bypass.
+#
+# Cache hits don't count: this checks `AiRequest` rows, which are only created
+# when a call actually hit the LLM. The caller is expected to probe its cache
+# *before* calling `allow?`.
+class AiRateLimiter
+  DAILY_LIMIT = 3
+
+  Result = Struct.new(:allowed, :remaining, :limit, :reset_at, :admin_bypass, keyword_init: true) do
+    def allowed? = allowed
+  end
+
+  def self.allow?(user, _feature)
+    return Result.new(allowed: true, remaining: nil, limit: nil, reset_at: nil, admin_bypass: true) if user&.admin?
+
+    used = AiRequest.today_for(user).count
+    remaining = [ DAILY_LIMIT - used, 0 ].max
+    Result.new(
+      allowed: used < DAILY_LIMIT,
+      remaining: remaining,
+      limit: DAILY_LIMIT,
+      reset_at: Time.current.utc.tomorrow.beginning_of_day,
+      admin_bypass: false
+    )
+  end
+
+  def self.record!(user:, feature:, provider:)
+    AiRequest.create!(user: user, feature: feature, provider: provider.to_s)
+  end
+end

--- a/app/services/content_generator.rb
+++ b/app/services/content_generator.rb
@@ -17,12 +17,15 @@ class ContentGenerator
   class << self
     # Topic shape: { category:, topic_key:, inputs: {...} }. Returns the parsed
     # payload from the AI provider — controller persists it as a ContentDraft.
-    def call(category:, topic_key:, inputs:, locale: nil)
+    # `user:` is the admin operator who triggered the draft; the rate limiter
+    # bypasses admins, so this never blocks, but the AiRequest row still gets
+    # logged for cost attribution.
+    def call(category:, topic_key:, inputs:, user:, locale: nil)
       topic = { category: category.to_s, topic_key: topic_key, inputs: inputs }
 
       assert_privacy!(inputs)
 
-      payload = AiInsightsService.social_post(topic, locale: locale)
+      payload = AiInsightsService.social_post(topic, user: user, locale: locale)
       raise GenerationFailed, "empty payload from provider" if payload.blank?
 
       enforce_length_guards!(payload)

--- a/config/initializers/ai_provider.rb
+++ b/config/initializers/ai_provider.rb
@@ -1,5 +1,10 @@
+# Default AI provider. Swap via `AI_PROVIDER` env var (e.g. `:anthropic`,
+# `:openai`) once a corresponding `AiProviders::*Provider` class exists.
+# Gemini is the only implementation today.
+Rails.application.config.ai_provider = ENV.fetch("AI_PROVIDER", "gemini").to_sym
+
 Rails.application.config.after_initialize do
-  if ENV["GEMINI_API_KEY"].blank?
+  if Rails.application.config.ai_provider == :gemini && ENV["GEMINI_API_KEY"].blank?
     Rails.logger.warn "GEMINI_API_KEY is not set. AI insights features will be unavailable."
   end
 end

--- a/db/migrate/20260523120000_create_ai_requests.rb
+++ b/db/migrate/20260523120000_create_ai_requests.rb
@@ -1,0 +1,13 @@
+class CreateAiRequests < ActiveRecord::Migration[8.0]
+  def change
+    create_table :ai_requests do |t|
+      t.references :user, null: false, foreign_key: true
+      t.string :feature, null: false
+      t.string :provider, null: false
+      t.datetime :created_at, null: false
+    end
+
+    # Hot path: counting a user's calls since the start of the day.
+    add_index :ai_requests, [ :user_id, :created_at ]
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_18_165219) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_23_120000) do
+  create_table "ai_requests", force: :cascade do |t|
+    t.integer "user_id", null: false
+    t.string "feature", null: false
+    t.string "provider", null: false
+    t.datetime "created_at", null: false
+    t.index ["user_id", "created_at"], name: "index_ai_requests_on_user_id_and_created_at"
+    t.index ["user_id"], name: "index_ai_requests_on_user_id"
+  end
+
   create_table "buy_plan_items", force: :cascade do |t|
     t.integer "buy_plan_id", null: false
     t.integer "stock_id", null: false
@@ -148,6 +157,7 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_18_165219) do
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true
   end
 
+  add_foreign_key "ai_requests", "users"
   add_foreign_key "buy_plan_items", "buy_plans"
   add_foreign_key "buy_plan_items", "stocks"
   add_foreign_key "buy_plans", "users"

--- a/spec/requests/api/v1/radar_insights_spec.rb
+++ b/spec/requests/api/v1/radar_insights_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe "Api::V1::Radars#insights", type: :request do
           get "/api/v1/radar/insights"
 
           expect(response).to have_http_status(:ok)
-          expect(AiInsightsService).to have_received(:radar_insights).with([], locale: nil, preferred_currency: "USD")
+          expect(AiInsightsService).to have_received(:radar_insights).with([], hash_including(locale: nil, preferred_currency: "USD"))
         end
       end
 

--- a/spec/services/ai_insights_service_spec.rb
+++ b/spec/services/ai_insights_service_spec.rb
@@ -1,4 +1,9 @@
+require "rails_helper"
+
 RSpec.describe AiInsightsService, type: :service do
+  let(:user) { create(:user) }
+  let(:admin) { create(:user, :admin) }
+
   let(:stocks_data) do
     [
       { symbol: "AAPL", price: 150.0, dividendYield: 0.6, payoutRatio: 15.0 },
@@ -28,31 +33,74 @@ RSpec.describe AiInsightsService, type: :service do
     }
   end
 
-  after do
-    described_class.instance_variable_set(:@provider, nil)
+  let(:provider) do
+    instance_double(
+      AiProviders::GeminiProvider,
+      name: :gemini,
+      radar_insights: radar_insights_result,
+      portfolio_insights: radar_insights_result,
+      stock_summary: stock_summary_result
+    )
+  end
+
+  before do
+    allow(AiProviders).to receive(:current).and_return(provider)
+    Rails.cache.clear
   end
 
   describe ".radar_insights" do
-    it "delegates to the provider" do
-      provider = instance_double(AiProviders::GeminiProvider, radar_insights: radar_insights_result)
-      allow(AiProviders::GeminiProvider).to receive(:new).and_return(provider)
-
-      result = described_class.radar_insights(stocks_data)
-
+    it "delegates to the provider on a cold cache" do
+      result = described_class.radar_insights(stocks_data, user: user)
       expect(result).to eq(radar_insights_result)
-      expect(provider).to have_received(:radar_insights).with(stocks_data, locale: nil, preferred_currency: nil)
+      expect(provider).to have_received(:radar_insights).once
+    end
+
+    it "logs an AiRequest after a successful LLM call" do
+      expect {
+        described_class.radar_insights(stocks_data, user: user)
+      }.to change { AiRequest.where(user: user, feature: "radar_insights").count }.by(1)
+    end
+
+    it "serves identical inputs from cache (no second LLM call, no second AiRequest)" do
+      described_class.radar_insights(stocks_data, user: user)
+      expect {
+        described_class.radar_insights(stocks_data, user: user)
+      }.not_to change(AiRequest, :count)
+      expect(provider).to have_received(:radar_insights).once
+    end
+
+    it "returns a rate-limited payload when the user is over quota" do
+      AiRateLimiter::DAILY_LIMIT.times { AiRateLimiter.record!(user: user, feature: "radar_insights", provider: :gemini) }
+
+      result = described_class.radar_insights(stocks_data, user: user)
+
+      expect(result[:rateLimited]).to be(true)
+      expect(result[:feature]).to eq("radar_insights")
+      expect(result[:limit]).to eq(AiRateLimiter::DAILY_LIMIT)
+      expect(provider).not_to have_received(:radar_insights)
+    end
+
+    it "serves cached data even when the user is over quota" do
+      described_class.radar_insights(stocks_data, user: admin) # warm the cache via admin call
+      AiRateLimiter::DAILY_LIMIT.times { AiRateLimiter.record!(user: user, feature: "radar_insights", provider: :gemini) }
+
+      result = described_class.radar_insights(stocks_data, user: user)
+      expect(result).to eq(radar_insights_result) # not rate-limited
     end
   end
 
   describe ".stock_summary" do
-    it "delegates to the provider" do
-      provider = instance_double(AiProviders::GeminiProvider, stock_summary: stock_summary_result)
-      allow(AiProviders::GeminiProvider).to receive(:new).and_return(provider)
-
-      result = described_class.stock_summary(stock_data)
-
+    it "delegates and logs" do
+      result = described_class.stock_summary(stock_data, user: user)
       expect(result).to eq(stock_summary_result)
-      expect(provider).to have_received(:stock_summary).with(stock_data, locale: nil, preferred_currency: nil)
+      expect(AiRequest.where(user: user, feature: "stock_summary").count).to eq(1)
+    end
+  end
+
+  describe ".portfolio_insights" do
+    it "delegates and logs" do
+      described_class.portfolio_insights(stocks_data, user: user)
+      expect(AiRequest.where(user: user, feature: "portfolio_insights").count).to eq(1)
     end
   end
 end

--- a/spec/services/ai_providers/gemini_provider_spec.rb
+++ b/spec/services/ai_providers/gemini_provider_spec.rb
@@ -57,13 +57,13 @@ RSpec.describe AiProviders::GeminiProvider, type: :service do
         expect(result[:strengths]).to include("Good diversification")
       end
 
-      it "caches responses" do
+      it "calls the API every time (caching lives in AiInsightsService)" do
         http = stub_gemini_request(gemini_radar_response)
 
         provider.radar_insights(stocks_data)
         provider.radar_insights(stocks_data)
 
-        expect(http).to have_received(:request).once
+        expect(http).to have_received(:request).twice
       end
     end
 

--- a/spec/services/ai_rate_limiter_spec.rb
+++ b/spec/services/ai_rate_limiter_spec.rb
@@ -1,0 +1,71 @@
+require "rails_helper"
+
+RSpec.describe AiRateLimiter, type: :service do
+  let(:user) { create(:user) }
+  let(:admin) { create(:user, :admin) }
+
+  describe ".allow?" do
+    it "allows the first DAILY_LIMIT calls for a regular user" do
+      AiRateLimiter::DAILY_LIMIT.times do
+        result = described_class.allow?(user, "radar_insights")
+        expect(result).to be_allowed
+        described_class.record!(user: user, feature: "radar_insights", provider: :gemini)
+      end
+    end
+
+    it "blocks the call after the daily limit is reached" do
+      AiRateLimiter::DAILY_LIMIT.times do
+        described_class.record!(user: user, feature: "radar_insights", provider: :gemini)
+      end
+
+      result = described_class.allow?(user, "radar_insights")
+      expect(result).not_to be_allowed
+      expect(result.remaining).to eq(0)
+      expect(result.limit).to eq(AiRateLimiter::DAILY_LIMIT)
+      expect(result.reset_at).to be_a(Time)
+    end
+
+    it "bypasses the limit for admins regardless of usage" do
+      (AiRateLimiter::DAILY_LIMIT * 5).times do
+        described_class.record!(user: admin, feature: "radar_insights", provider: :gemini)
+      end
+
+      result = described_class.allow?(admin, "radar_insights")
+      expect(result).to be_allowed
+      expect(result.admin_bypass).to be(true)
+    end
+
+    it "only counts requests from the current UTC day" do
+      AiRequest.create!(user: user, feature: "radar_insights", provider: "gemini", created_at: 2.days.ago)
+
+      # Yesterday's usage doesn't count toward today's quota.
+      AiRateLimiter::DAILY_LIMIT.times do
+        result = described_class.allow?(user, "radar_insights")
+        expect(result).to be_allowed
+        described_class.record!(user: user, feature: "radar_insights", provider: :gemini)
+      end
+    end
+
+    it "counts across features (the limit is per user, not per feature)" do
+      described_class.record!(user: user, feature: "radar_insights", provider: :gemini)
+      described_class.record!(user: user, feature: "portfolio_insights", provider: :gemini)
+      described_class.record!(user: user, feature: "stock_summary", provider: :gemini)
+
+      result = described_class.allow?(user, "radar_insights")
+      expect(result).not_to be_allowed
+    end
+  end
+
+  describe ".record!" do
+    it "creates an AiRequest tagged with the provider name" do
+      expect {
+        described_class.record!(user: user, feature: "stock_summary", provider: :gemini)
+      }.to change(AiRequest, :count).by(1)
+
+      record = AiRequest.last
+      expect(record.user).to eq(user)
+      expect(record.feature).to eq("stock_summary")
+      expect(record.provider).to eq("gemini")
+    end
+  end
+end

--- a/spec/services/content_generator_spec.rb
+++ b/spec/services/content_generator_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe ContentGenerator do
+  let(:user) { create(:user, :admin) }
   let(:payload) do
     {
       headline: "AAPL is paying its dividend",
@@ -19,7 +20,8 @@ RSpec.describe ContentGenerator do
       result = described_class.call(
         category: "stock_of_the_day",
         topic_key: "AAPL",
-        inputs: { symbol: "AAPL", dividend_yield: 0.6 }
+        inputs: { symbol: "AAPL", dividend_yield: 0.6 },
+        user: user
       )
       expect(result[:headline]).to eq("AAPL is paying its dividend")
     end
@@ -28,7 +30,7 @@ RSpec.describe ContentGenerator do
       allow(AiInsightsService).to receive(:social_post).and_return(nil)
 
       expect {
-        described_class.call(category: "stock_of_the_day", topic_key: "AAPL", inputs: {})
+        described_class.call(category: "stock_of_the_day", topic_key: "AAPL", inputs: {}, user: user)
       }.to raise_error(described_class::GenerationFailed)
     end
 
@@ -36,7 +38,7 @@ RSpec.describe ContentGenerator do
       long = "A" * 300
       allow(AiInsightsService).to receive(:social_post).and_return(payload.merge(x: { text: long }))
 
-      result = described_class.call(category: "stock_of_the_day", topic_key: "AAPL", inputs: {})
+      result = described_class.call(category: "stock_of_the_day", topic_key: "AAPL", inputs: {}, user: user)
 
       expect(result[:x][:text].length).to eq(described_class::X_MAX_LENGTH)
       expect(result[:truncated_x]).to be true
@@ -45,13 +47,13 @@ RSpec.describe ContentGenerator do
     describe 'privacy assertion' do
       it 'raises if the input contains a portfolio_slug reference' do
         expect {
-          described_class.call(category: "pulse_aggregates", topic_key: "X", inputs: { leaked: "portfolio_slug=foo" })
+          described_class.call(category: "pulse_aggregates", topic_key: "X", inputs: { leaked: "portfolio_slug=foo" }, user: user)
         }.to raise_error(described_class::PrivacyViolation, /portfolio_slug/)
       end
 
       it 'raises if the input contains an email address' do
         expect {
-          described_class.call(category: "x", topic_key: "y", inputs: { from: "alice@example.com" })
+          described_class.call(category: "x", topic_key: "y", inputs: { from: "alice@example.com" }, user: user)
         }.to raise_error(described_class::PrivacyViolation, /forbidden/)
       end
 
@@ -60,7 +62,7 @@ RSpec.describe ContentGenerator do
           payload.merge(x: { text: "Email alice@example.com for more!" })
         )
         expect {
-          described_class.call(category: "stock_of_the_day", topic_key: "AAPL", inputs: {})
+          described_class.call(category: "stock_of_the_day", topic_key: "AAPL", inputs: {}, user: user)
         }.to raise_error(described_class::PrivacyViolation)
       end
 
@@ -69,7 +71,7 @@ RSpec.describe ContentGenerator do
           payload.merge(linkedin: { text: "Check out pulse.quantic.es/p/alice" })
         )
         expect {
-          described_class.call(category: "stock_of_the_day", topic_key: "AAPL", inputs: {})
+          described_class.call(category: "stock_of_the_day", topic_key: "AAPL", inputs: {}, user: user)
         }.to raise_error(described_class::PrivacyViolation)
       end
     end


### PR DESCRIPTION
First half of the Telegram-bot effort (plan: \`~/.claude/plans/cached-doodling-scroll.md\`). The bot's NLU calls will add to AI usage, so we land cost controls + a clean provider abstraction *before* the new traffic shows up.

## Summary

- **3 LLM calls per UTC day** per non-admin user, across every AI surface (radar insights, portfolio insights, stock summaries, future bot). Cache hits don't count — only actual LLM calls consume quota, so cached insights stay free even at the limit. Admins bypass.
- **Friendly inline notice** on insight cards when the user is over quota (en + es). No paywall language; honest about the cost.
- **Provider-agnostic seams**: `AiInsightsService` calls `AiProviders.current` instead of hard-coding `GeminiProvider.new`. Selection lives in `config/initializers/ai_provider.rb` with `AI_PROVIDER` env override. Caching moved out of the provider and into the service so each provider only worries about talking to its API. Adding Anthropic / OpenAI is now a 1-day task (no second provider in this PR).
- **`AiRequest` log table** records each LLM hit with user/feature/provider — drives the limiter today, future cost analytics tomorrow.
- **README**: new sections on \`AI_PROVIDER\` and the daily-limit policy.

## Test plan

- [x] \`bundle exec rspec\` — full suite green (593 examples, 0 failures)
- [x] \`bin/rubocop\` on touched Ruby — clean
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx vite build\` — succeeds
- [x] New: \`spec/services/ai_rate_limiter_spec.rb\` covers limit / admin bypass / day boundary / cross-feature counting
- [x] Extended: \`spec/services/ai_insights_service_spec.rb\` covers cold-cache LLM call, cache hit (no second call, no second log), rate-limited payload, cached-data-served-while-rate-limited
- [ ] Manual: hit \`/api/v1/stocks/:id/ai_summary\` 4× as a non-admin → 4th returns \`rateLimited: true\`; UI shows the amber notice
- [ ] Manual: same with admin → all calls succeed
- [ ] Manual: switch UI language to ES → notice copy reads naturally

🤖 Generated with [Claude Code](https://claude.com/claude-code)