### PR TITLE
Wire Telegram env vars through Kamal secrets

### DIFF
--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -7,7 +7,7 @@
 # and only ${VAR} interpolation is supported (no ${VAR:-default}).
 
 REGISTRY=$(kamal secrets fetch --adapter 1password --account ${OP_ACCOUNT} --from ${OP_VAULT}/registry KAMAL_REGISTRY_PASSWORD)
-DP=$(kamal secrets fetch --adapter 1password --account ${OP_ACCOUNT} --from ${OP_VAULT}/dividend-portfolio RAILS_MASTER_KEY GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GEMINI_API_KEY VITE_LOGO_SERVICE_URL VITE_LOGO_SERVICE_API_KEY)
+DP=$(kamal secrets fetch --adapter 1password --account ${OP_ACCOUNT} --from ${OP_VAULT}/dividend-portfolio RAILS_MASTER_KEY GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GEMINI_API_KEY VITE_LOGO_SERVICE_URL VITE_LOGO_SERVICE_API_KEY TELEGRAM_BOT_TOKEN TELEGRAM_BOT_HANDLE TELEGRAM_WEBHOOK_SECRET)
 
 KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD ${REGISTRY})
 RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY ${DP})
@@ -16,3 +16,6 @@ GOOGLE_CLIENT_SECRET=$(kamal secrets extract GOOGLE_CLIENT_SECRET ${DP})
 GEMINI_API_KEY=$(kamal secrets extract GEMINI_API_KEY ${DP})
 VITE_LOGO_SERVICE_URL=$(kamal secrets extract VITE_LOGO_SERVICE_URL ${DP})
 VITE_LOGO_SERVICE_API_KEY=$(kamal secrets extract VITE_LOGO_SERVICE_API_KEY ${DP})
+TELEGRAM_BOT_TOKEN=$(kamal secrets extract TELEGRAM_BOT_TOKEN ${DP})
+TELEGRAM_BOT_HANDLE=$(kamal secrets extract TELEGRAM_BOT_HANDLE ${DP})
+TELEGRAM_WEBHOOK_SECRET=$(kamal secrets extract TELEGRAM_WEBHOOK_SECRET ${DP})

--- a/config/deploy.yml
+++ b/config/deploy.yml
@@ -35,6 +35,9 @@ env:
     - GOOGLE_CLIENT_ID
     - GOOGLE_CLIENT_SECRET
     - GEMINI_API_KEY
+    - TELEGRAM_BOT_TOKEN
+    - TELEGRAM_BOT_HANDLE
+    - TELEGRAM_WEBHOOK_SECRET
   clear:
     # Run the Solid Queue Supervisor inside the web server's Puma process to do jobs.
     # When you start using multiple servers, you should split out job processing to a dedicated machine.


### PR DESCRIPTION
## Summary

PR #165 shipped the Telegram bot code but the container env never got the three vars it needs. Teach \`.kamal/secrets\` to fetch them from the existing \`dividend-portfolio\` 1Password item and \`config/deploy.yml\` to inject them.

Fields expected in 1Password: \`TELEGRAM_BOT_TOKEN\`, \`TELEGRAM_BOT_HANDLE\`, \`TELEGRAM_WEBHOOK_SECRET\` (confirmed present).

## Test plan
- [ ] Merge → CI → auto-deploy via Kamal
- [ ] After deploy completes, run on prod:
  \`\`\`sh
  bundle exec kamal app exec --interactive \\
    "bash -c 'TELEGRAM_WEBHOOK_URL=https://quantic.es/api/v1/telegram/webhook bin/rails telegram:set_webhook'"
  \`\`\`
  Expected: \`{"ok":true,"result":true,"description":"Webhook was set"}\`
- [ ] Settings → Connect Telegram → tap deep link → \`/start <code>\` → bot replies "✅ Linked"

🤖 Generated with [Claude Code](https://claude.com/claude-code)