### PR TITLE
Fix Ruby 3 kwargs trap in TelegramLinksController

### DIFF
--- a/app/controllers/api/v1/telegram_links_controller.rb
+++ b/app/controllers/api/v1/telegram_links_controller.rb
@@ -20,17 +20,17 @@ module Api
         end
 
         link = UserTelegramLink.start_linking!(Current.user)
-        render_success(
+        render_success({
           code: link.code,
           deepLinkUrl: "https://t.me/#{TelegramBot::Client.bot_handle}?start=#{link.code}",
           expiresAt: link.expires_at.iso8601
-        )
+        })
       end
 
       # DELETE /api/v1/telegram_link → { unlinked: true }
       def destroy
         UserTelegramLink.where(user: Current.user).delete_all
-        render_success(unlinked: true)
+        render_success({ unlinked: true })
       end
 
       private

--- a/spec/requests/api/v1/telegram_links_controller_spec.rb
+++ b/spec/requests/api/v1/telegram_links_controller_spec.rb
@@ -1,0 +1,55 @@
+require "rails_helper"
+
+RSpec.describe "Api::V1::TelegramLinks", type: :request do
+  let(:user) { create(:user) }
+
+  before do
+    sign_in user
+    ENV["TELEGRAM_BOT_HANDLE"] = "QuanticAppBot"
+  end
+
+  after { ENV.delete("TELEGRAM_BOT_HANDLE") }
+
+  describe "GET /api/v1/telegram_link" do
+    it "returns connected: false when the user has no link" do
+      get "/api/v1/telegram_link"
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["data"]).to eq("connected" => false)
+    end
+
+    it "returns the link details when the user is linked" do
+      UserTelegramLink.create!(user: user, chat_id: "123", telegram_user_id: "u", linked_at: Time.current)
+      get "/api/v1/telegram_link"
+      data = JSON.parse(response.body)["data"]
+      expect(data["connected"]).to be(true)
+      expect(data["telegramUserId"]).to eq("u")
+    end
+  end
+
+  describe "POST /api/v1/telegram_link" do
+    it "issues a fresh code + deep-link URL" do
+      post "/api/v1/telegram_link"
+      expect(response).to have_http_status(:ok)
+      data = JSON.parse(response.body)["data"]
+      expect(data["code"]).to be_present
+      expect(data["deepLinkUrl"]).to start_with("https://t.me/QuanticAppBot?start=")
+      expect(data["expiresAt"]).to be_present
+    end
+
+    it "503s when the bot handle isn't configured" do
+      ENV.delete("TELEGRAM_BOT_HANDLE")
+      post "/api/v1/telegram_link"
+      expect(response).to have_http_status(:service_unavailable)
+    end
+  end
+
+  describe "DELETE /api/v1/telegram_link" do
+    it "removes the user's link rows and confirms" do
+      UserTelegramLink.create!(user: user, chat_id: "123", telegram_user_id: "u", linked_at: Time.current)
+      delete "/api/v1/telegram_link"
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)["data"]).to eq("unlinked" => true)
+      expect(UserTelegramLink.where(user: user)).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
## Summary

The Connect Telegram button 500s on prod with \`ArgumentError - wrong number of arguments (given 0, expected 1)\` at \`render_success\`. Ruby 3 treats \`render_success(code: ..., deepLinkUrl: ...)\` as keyword arguments — and \`render_success(data, status: :ok)\` doesn't declare those kwargs, so it crashes before even rendering JSON. Same bug existed in \`#destroy\`. Both fixed by wrapping the payload in explicit braces.

The new request spec covers all three actions (show / create / destroy including the bot-handle-missing 503 branch) and would have caught this before deploy.

## Test plan
- [x] \`bundle exec rspec spec/requests/api/v1/telegram_links_controller_spec.rb\` — 5/5 green
- [x] Spec demonstrably reproduces the bug if the controller fix is reverted
- [ ] After merge + deploy: tap Connect Telegram in Settings → opens Telegram with /start <code>

🤖 Generated with [Claude Code](https://claude.com/claude-code)