### PR TITLE
Migrate Kamal secrets from 1Password to Bitwarden (consumer)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,12 +17,10 @@ jobs:
 
     env:
       DOCKER_BUILDKIT: 1
-      # All deploy secrets are pulled from 1Password by .kamal/secrets.
-      # OP_SERVICE_ACCOUNT_TOKEN is the only secret; OP_ACCOUNT/OP_VAULT are
-      # plain config that .kamal/secrets interpolates.
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
-      OP_ACCOUNT: my.1password.com
-      OP_VAULT: quantic-prod
+      # Bitwarden account email — used by the kamal bitwarden adapter
+      # (passed as --account in .kamal/secrets). Not strictly secret, but
+      # kept out of git as a personal-info hygiene measure.
+      BW_ACCOUNT: ${{ secrets.BW_ACCOUNT }}
 
     steps:
       - name: Checkout code
@@ -36,8 +34,22 @@ jobs:
           ruby-version: .ruby-version
           bundler-cache: true
 
-      - name: Install 1Password CLI
-        uses: 1password/install-cli-action@v3
+      - name: Install Bitwarden CLI
+        run: npm install -g @bitwarden/cli
+
+      # Kamal's bitwarden adapter calls `bw login <email>` interactively
+      # (no --apikey support), so we pre-login + pre-unlock here and pass
+      # BW_SESSION through to the deploy step via GITHUB_ENV. Kamal then
+      # sees status=unlocked and skips its own login attempt.
+      - name: Login + unlock Bitwarden vault
+        env:
+          BW_CLIENTID: ${{ secrets.BW_CLIENTID }}
+          BW_CLIENTSECRET: ${{ secrets.BW_CLIENTSECRET }}
+          BW_PASSWORD: ${{ secrets.BW_PASSWORD }}
+        run: |
+          bw config server https://vault.bitwarden.eu
+          bw login --apikey
+          echo "BW_SESSION=$(bw unlock --raw --passwordenv BW_PASSWORD)" >> "$GITHUB_ENV"
 
       - name: Set up SSH agent
         uses: webfactory/ssh-agent@v0.9.0

--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -1,21 +1,23 @@
-# Secrets for Kamal deployment — sourced from 1Password.
+# Secrets for Kamal deployment — sourced from Bitwarden Password Manager.
 #
-# Requires OP_SERVICE_ACCOUNT_TOKEN, OP_ACCOUNT, OP_VAULT in the shell env
-# (local: repo .env via direnv; CI: deploy.yml env block).
+# Requires BW_CLIENTID, BW_CLIENTSECRET, and BW_PASSWORD in the shell env
+# (local: repo .env via direnv; CI: deploy.yml env block). The `bw` CLI must
+# be on PATH; kamal's bitwarden adapter handles login + vault unlock.
 #
 # Parsed by dotenv line-by-line (NOT bash): each $(...) must stay on one line,
 # and only ${VAR} interpolation is supported (no ${VAR:-default}).
+#
+# To switch back to 1Password: see .kamal/secrets.1password.example.
 
-REGISTRY=$(kamal secrets fetch --adapter 1password --account ${OP_ACCOUNT} --from ${OP_VAULT}/registry KAMAL_REGISTRY_PASSWORD)
-DP=$(kamal secrets fetch --adapter 1password --account ${OP_ACCOUNT} --from ${OP_VAULT}/dividend-portfolio RAILS_MASTER_KEY GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GEMINI_API_KEY VITE_LOGO_SERVICE_URL VITE_LOGO_SERVICE_API_KEY TELEGRAM_BOT_TOKEN TELEGRAM_BOT_HANDLE TELEGRAM_WEBHOOK_SECRET)
+ALL=$(kamal secrets fetch --adapter bitwarden --from quantic-prod KAMAL_REGISTRY_PASSWORD RAILS_MASTER_KEY GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GEMINI_API_KEY VITE_LOGO_SERVICE_URL VITE_LOGO_SERVICE_API_KEY TELEGRAM_BOT_TOKEN TELEGRAM_BOT_HANDLE TELEGRAM_WEBHOOK_SECRET)
 
-KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD ${REGISTRY})
-RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY ${DP})
-GOOGLE_CLIENT_ID=$(kamal secrets extract GOOGLE_CLIENT_ID ${DP})
-GOOGLE_CLIENT_SECRET=$(kamal secrets extract GOOGLE_CLIENT_SECRET ${DP})
-GEMINI_API_KEY=$(kamal secrets extract GEMINI_API_KEY ${DP})
-VITE_LOGO_SERVICE_URL=$(kamal secrets extract VITE_LOGO_SERVICE_URL ${DP})
-VITE_LOGO_SERVICE_API_KEY=$(kamal secrets extract VITE_LOGO_SERVICE_API_KEY ${DP})
-TELEGRAM_BOT_TOKEN=$(kamal secrets extract TELEGRAM_BOT_TOKEN ${DP})
-TELEGRAM_BOT_HANDLE=$(kamal secrets extract TELEGRAM_BOT_HANDLE ${DP})
-TELEGRAM_WEBHOOK_SECRET=$(kamal secrets extract TELEGRAM_WEBHOOK_SECRET ${DP})
+KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD ${ALL})
+RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY ${ALL})
+GOOGLE_CLIENT_ID=$(kamal secrets extract GOOGLE_CLIENT_ID ${ALL})
+GOOGLE_CLIENT_SECRET=$(kamal secrets extract GOOGLE_CLIENT_SECRET ${ALL})
+GEMINI_API_KEY=$(kamal secrets extract GEMINI_API_KEY ${ALL})
+VITE_LOGO_SERVICE_URL=$(kamal secrets extract VITE_LOGO_SERVICE_URL ${ALL})
+VITE_LOGO_SERVICE_API_KEY=$(kamal secrets extract VITE_LOGO_SERVICE_API_KEY ${ALL})
+TELEGRAM_BOT_TOKEN=$(kamal secrets extract TELEGRAM_BOT_TOKEN ${ALL})
+TELEGRAM_BOT_HANDLE=$(kamal secrets extract TELEGRAM_BOT_HANDLE ${ALL})
+TELEGRAM_WEBHOOK_SECRET=$(kamal secrets extract TELEGRAM_WEBHOOK_SECRET ${ALL})

--- a/.kamal/secrets
+++ b/.kamal/secrets
@@ -1,15 +1,17 @@
 # Secrets for Kamal deployment — sourced from Bitwarden Password Manager.
 #
-# Requires BW_CLIENTID, BW_CLIENTSECRET, and BW_PASSWORD in the shell env
-# (local: repo .env via direnv; CI: deploy.yml env block). The `bw` CLI must
-# be on PATH; kamal's bitwarden adapter handles login + vault unlock.
+# Requires BW_ACCOUNT (your Bitwarden login email) and BW_SESSION (obtained
+# from `bw unlock --raw --passwordenv BW_PASSWORD`) in the shell env.
+# Local: repo .env via direnv (BW_ACCOUNT) + a wrapper that exports
+# BW_SESSION before running kamal. CI: deploy.yml does both steps before
+# any kamal command runs. The `bw` CLI must be on PATH.
 #
 # Parsed by dotenv line-by-line (NOT bash): each $(...) must stay on one line,
 # and only ${VAR} interpolation is supported (no ${VAR:-default}).
 #
 # To switch back to 1Password: see .kamal/secrets.1password.example.
 
-ALL=$(kamal secrets fetch --adapter bitwarden --from quantic-prod KAMAL_REGISTRY_PASSWORD RAILS_MASTER_KEY GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GEMINI_API_KEY VITE_LOGO_SERVICE_URL VITE_LOGO_SERVICE_API_KEY TELEGRAM_BOT_TOKEN TELEGRAM_BOT_HANDLE TELEGRAM_WEBHOOK_SECRET)
+ALL=$(kamal secrets fetch --adapter bitwarden --account ${BW_ACCOUNT} --from quantic-prod KAMAL_REGISTRY_PASSWORD RAILS_MASTER_KEY GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GEMINI_API_KEY VITE_LOGO_SERVICE_URL VITE_LOGO_SERVICE_API_KEY TELEGRAM_BOT_TOKEN TELEGRAM_BOT_HANDLE TELEGRAM_WEBHOOK_SECRET)
 
 KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD ${ALL})
 RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY ${ALL})

--- a/.kamal/secrets.1password.example
+++ b/.kamal/secrets.1password.example
@@ -1,0 +1,21 @@
+# Secrets for Kamal deployment — sourced from 1Password.
+#
+# Requires OP_SERVICE_ACCOUNT_TOKEN, OP_ACCOUNT, OP_VAULT in the shell env
+# (local: repo .env via direnv; CI: deploy.yml env block).
+#
+# Parsed by dotenv line-by-line (NOT bash): each $(...) must stay on one line,
+# and only ${VAR} interpolation is supported (no ${VAR:-default}).
+
+REGISTRY=$(kamal secrets fetch --adapter 1password --account ${OP_ACCOUNT} --from ${OP_VAULT}/registry KAMAL_REGISTRY_PASSWORD)
+DP=$(kamal secrets fetch --adapter 1password --account ${OP_ACCOUNT} --from ${OP_VAULT}/dividend-portfolio RAILS_MASTER_KEY GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GEMINI_API_KEY VITE_LOGO_SERVICE_URL VITE_LOGO_SERVICE_API_KEY TELEGRAM_BOT_TOKEN TELEGRAM_BOT_HANDLE TELEGRAM_WEBHOOK_SECRET)
+
+KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD ${REGISTRY})
+RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY ${DP})
+GOOGLE_CLIENT_ID=$(kamal secrets extract GOOGLE_CLIENT_ID ${DP})
+GOOGLE_CLIENT_SECRET=$(kamal secrets extract GOOGLE_CLIENT_SECRET ${DP})
+GEMINI_API_KEY=$(kamal secrets extract GEMINI_API_KEY ${DP})
+VITE_LOGO_SERVICE_URL=$(kamal secrets extract VITE_LOGO_SERVICE_URL ${DP})
+VITE_LOGO_SERVICE_API_KEY=$(kamal secrets extract VITE_LOGO_SERVICE_API_KEY ${DP})
+TELEGRAM_BOT_TOKEN=$(kamal secrets extract TELEGRAM_BOT_TOKEN ${DP})
+TELEGRAM_BOT_HANDLE=$(kamal secrets extract TELEGRAM_BOT_HANDLE ${DP})
+TELEGRAM_WEBHOOK_SECRET=$(kamal secrets extract TELEGRAM_WEBHOOK_SECRET ${DP})

--- a/.kamal/secrets.beta
+++ b/.kamal/secrets.beta
@@ -1,19 +1,21 @@
-# Secrets for the beta destination — sourced from 1Password.
+# Secrets for the beta destination — sourced from Bitwarden Password Manager.
 #
-# Requires OP_SERVICE_ACCOUNT_TOKEN, OP_ACCOUNT, OP_VAULT in the shell env
-# (local: repo .env via direnv; CI: deploy.yml env block). Beta shares prod
-# secret values; deploy.beta.yml only overrides env.clear/proxy/volumes.
+# Requires BW_CLIENTID, BW_CLIENTSECRET, and BW_PASSWORD in the shell env.
+# Beta and prod use *separate* Bitwarden items (quantic-prod vs quantic-beta)
+# so the two environments stay isolated. The Telegram secrets aren't included
+# here — that feature is prod-only for now.
 #
 # Parsed by dotenv line-by-line (NOT bash): each $(...) must stay on one line,
 # and only ${VAR} interpolation is supported (no ${VAR:-default}).
+#
+# To switch back to 1Password: see .kamal/secrets.beta.1password.example.
 
-REGISTRY=$(kamal secrets fetch --adapter 1password --account ${OP_ACCOUNT} --from ${OP_VAULT}/registry KAMAL_REGISTRY_PASSWORD)
-DP=$(kamal secrets fetch --adapter 1password --account ${OP_ACCOUNT} --from ${OP_VAULT}/dividend-portfolio RAILS_MASTER_KEY GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GEMINI_API_KEY VITE_LOGO_SERVICE_URL VITE_LOGO_SERVICE_API_KEY)
+ALL=$(kamal secrets fetch --adapter bitwarden --from quantic-beta KAMAL_REGISTRY_PASSWORD RAILS_MASTER_KEY GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GEMINI_API_KEY VITE_LOGO_SERVICE_URL VITE_LOGO_SERVICE_API_KEY)
 
-KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD ${REGISTRY})
-RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY ${DP})
-GOOGLE_CLIENT_ID=$(kamal secrets extract GOOGLE_CLIENT_ID ${DP})
-GOOGLE_CLIENT_SECRET=$(kamal secrets extract GOOGLE_CLIENT_SECRET ${DP})
-GEMINI_API_KEY=$(kamal secrets extract GEMINI_API_KEY ${DP})
-VITE_LOGO_SERVICE_URL=$(kamal secrets extract VITE_LOGO_SERVICE_URL ${DP})
-VITE_LOGO_SERVICE_API_KEY=$(kamal secrets extract VITE_LOGO_SERVICE_API_KEY ${DP})
+KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD ${ALL})
+RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY ${ALL})
+GOOGLE_CLIENT_ID=$(kamal secrets extract GOOGLE_CLIENT_ID ${ALL})
+GOOGLE_CLIENT_SECRET=$(kamal secrets extract GOOGLE_CLIENT_SECRET ${ALL})
+GEMINI_API_KEY=$(kamal secrets extract GEMINI_API_KEY ${ALL})
+VITE_LOGO_SERVICE_URL=$(kamal secrets extract VITE_LOGO_SERVICE_URL ${ALL})
+VITE_LOGO_SERVICE_API_KEY=$(kamal secrets extract VITE_LOGO_SERVICE_API_KEY ${ALL})

--- a/.kamal/secrets.beta
+++ b/.kamal/secrets.beta
@@ -1,16 +1,19 @@
 # Secrets for the beta destination — sourced from Bitwarden Password Manager.
 #
 # Requires BW_CLIENTID, BW_CLIENTSECRET, and BW_PASSWORD in the shell env.
-# Beta and prod use *separate* Bitwarden items (quantic-prod vs quantic-beta)
-# so the two environments stay isolated. The Telegram secrets aren't included
-# here — that feature is prod-only for now.
+# Beta shares prod secret values (same Bitwarden item) — `deploy.beta.yml`
+# only overrides env.clear/proxy/volumes. The Telegram secrets aren't
+# included here — that feature is prod-only for now.
+#
+# If you ever want true env isolation, create a `quantic-beta` Bitwarden
+# item with distinct values and swap the `--from quantic-prod` below.
 #
 # Parsed by dotenv line-by-line (NOT bash): each $(...) must stay on one line,
 # and only ${VAR} interpolation is supported (no ${VAR:-default}).
 #
 # To switch back to 1Password: see .kamal/secrets.beta.1password.example.
 
-ALL=$(kamal secrets fetch --adapter bitwarden --from quantic-beta KAMAL_REGISTRY_PASSWORD RAILS_MASTER_KEY GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GEMINI_API_KEY VITE_LOGO_SERVICE_URL VITE_LOGO_SERVICE_API_KEY)
+ALL=$(kamal secrets fetch --adapter bitwarden --account ${BW_ACCOUNT} --from quantic-prod KAMAL_REGISTRY_PASSWORD RAILS_MASTER_KEY GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GEMINI_API_KEY VITE_LOGO_SERVICE_URL VITE_LOGO_SERVICE_API_KEY)
 
 KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD ${ALL})
 RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY ${ALL})

--- a/.kamal/secrets.beta.1password.example
+++ b/.kamal/secrets.beta.1password.example
@@ -1,0 +1,19 @@
+# Secrets for the beta destination — sourced from 1Password.
+#
+# Requires OP_SERVICE_ACCOUNT_TOKEN, OP_ACCOUNT, OP_VAULT in the shell env
+# (local: repo .env via direnv; CI: deploy.yml env block). Beta shares prod
+# secret values; deploy.beta.yml only overrides env.clear/proxy/volumes.
+#
+# Parsed by dotenv line-by-line (NOT bash): each $(...) must stay on one line,
+# and only ${VAR} interpolation is supported (no ${VAR:-default}).
+
+REGISTRY=$(kamal secrets fetch --adapter 1password --account ${OP_ACCOUNT} --from ${OP_VAULT}/registry KAMAL_REGISTRY_PASSWORD)
+DP=$(kamal secrets fetch --adapter 1password --account ${OP_ACCOUNT} --from ${OP_VAULT}/dividend-portfolio RAILS_MASTER_KEY GOOGLE_CLIENT_ID GOOGLE_CLIENT_SECRET GEMINI_API_KEY VITE_LOGO_SERVICE_URL VITE_LOGO_SERVICE_API_KEY)
+
+KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD ${REGISTRY})
+RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY ${DP})
+GOOGLE_CLIENT_ID=$(kamal secrets extract GOOGLE_CLIENT_ID ${DP})
+GOOGLE_CLIENT_SECRET=$(kamal secrets extract GOOGLE_CLIENT_SECRET ${DP})
+GEMINI_API_KEY=$(kamal secrets extract GEMINI_API_KEY ${DP})
+VITE_LOGO_SERVICE_URL=$(kamal secrets extract VITE_LOGO_SERVICE_URL ${DP})
+VITE_LOGO_SERVICE_API_KEY=$(kamal secrets extract VITE_LOGO_SERVICE_API_KEY ${DP})

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ One-time operator setup:
 1. Open Telegram, message `@BotFather`, run `/newbot`, pick a name and handle
    (e.g. `QuanticAppBot`). BotFather returns a token.
 2. Optional polish: `/setdescription`, `/setabouttext`, `/setuserpic`.
-3. Add env vars to your environment (1Password for prod):
+3. Add env vars to your environment (Bitwarden for prod):
    ```sh
    TELEGRAM_BOT_TOKEN=...        # from @BotFather
    TELEGRAM_BOT_HANDLE=QuanticAppBot   # without the @
@@ -296,25 +296,50 @@ If you fork this project, update these files with your own server, domains, and 
 
 - `config/deploy.yml` — production server IP, domains, and container registry
 - `config/deploy.beta.yml` — beta domain
-- `.kamal/secrets` and `.kamal/secrets.beta` — fetch secrets from 1Password (no raw values)
+- `.kamal/secrets` and `.kamal/secrets.beta` — fetch secrets from Bitwarden (no raw values)
 
-Deploy secrets live in a 1Password vault and are pulled at deploy time by `.kamal/secrets`
-via `kamal secrets fetch --adapter 1password`. The only GitHub Actions secrets you need:
+Deploy secrets live in two Secure Note items in a personal
+[Bitwarden](https://bitwarden.com/) vault (`quantic-prod` and `quantic-beta`,
+each holding the relevant keys as custom fields), pulled at deploy time
+by `.kamal/secrets` via `kamal secrets fetch --adapter bitwarden`. The
+GitHub Actions secrets you need:
 
 | Secret | Description |
 |---|---|
 | `SSH_PRIVATE_KEY` | SSH key authorized on your server |
-| `OP_SERVICE_ACCOUNT_TOKEN` | 1Password service account token — `.kamal/secrets` uses it to fetch all other secrets |
+| `BW_ACCOUNT` | Your Bitwarden login email (kept out of git) |
+| `BW_CLIENTID` | Bitwarden personal API key — client_id (Account Settings → Security → Keys) |
+| `BW_CLIENTSECRET` | Bitwarden personal API key — client_secret |
+| `BW_PASSWORD` | Bitwarden master password — used to unlock the vault non-interactively in CI |
 
-`.github/workflows/deploy.yml` also sets two plain (non-secret) env values — `OP_ACCOUNT` and
-`OP_VAULT` — that select the 1Password account and vault.
+The deploy workflow installs the `bw` CLI via `npm install -g @bitwarden/cli`,
+configures the EU server, runs `bw login --apikey`, then
+`bw unlock --raw --passwordenv BW_PASSWORD` and exports the resulting
+`BW_SESSION` to `$GITHUB_ENV`. Kamal sees status=unlocked and skips its
+own login attempt — it just inherits the session and runs `bw get item ...`
+against the vault.
+
+#### Switching back to 1Password
+
+The current Bitwarden setup replaced an earlier 1Password integration.
+The 1P version is preserved verbatim at `.kamal/secrets.1password.example`
+(and `.kamal/secrets.beta.1password.example`). To roll back:
+
+```sh
+cp .kamal/secrets.1password.example .kamal/secrets
+cp .kamal/secrets.beta.1password.example .kamal/secrets.beta
+```
+
+Then revert the BW-related changes in `.github/workflows/deploy.yml`
+(swap the "Install Bitwarden CLI" step for `1password/install-cli-action@v3`,
+and the `BW_*` env vars for `OP_SERVICE_ACCOUNT_TOKEN` / `OP_ACCOUNT` / `OP_VAULT`).
 
 #### Local development
 
 Copy the sample files and fill in your values (both are gitignored; `direnv` loads `.env`):
 
 ```
-cp env.sample .env       # fill in OP_SERVICE_ACCOUNT_TOKEN + dev config
+cp env.sample .env       # fill in BW_CLIENTID + BW_CLIENTSECRET + BW_PASSWORD + dev config
 cp envrc.sample .envrc
 direnv allow
 ```

--- a/env.sample
+++ b/env.sample
@@ -1,11 +1,18 @@
 # Copy to .env (gitignored) and fill in. Loaded by direnv via .envrc.
 
-# === Deploy bootstrap (1Password) ===
-# All deploy secrets are pulled from 1Password by .kamal/secrets. These three
-# values are the only ones you set yourself.
-OP_SERVICE_ACCOUNT_TOKEN=your_1password_service_account_token
-OP_ACCOUNT=my.1password.com
-OP_VAULT=quantic-prod
+# === Deploy bootstrap (Bitwarden) ===
+# All deploy secrets are pulled from Bitwarden by .kamal/secrets. Set these
+# four; the deploy workflow logs in + unlocks the vault and passes a
+# BW_SESSION through to kamal. For local kamal use, first run:
+#   bw config server https://vault.bitwarden.eu   # one-time per machine
+#   bw login --apikey                              # uses BW_CLIENTID/SECRET
+#   export BW_SESSION=$(bw unlock --raw --passwordenv BW_PASSWORD)
+# Then any `bundle exec kamal ...` call works.
+# (To switch back to 1Password, see .kamal/secrets.1password.example.)
+BW_ACCOUNT=your_bitwarden_login_email
+BW_CLIENTID=your_bitwarden_personal_api_client_id
+BW_CLIENTSECRET=your_bitwarden_personal_api_client_secret
+BW_PASSWORD=your_bitwarden_master_password
 
 # === Local dev app config ===
 


### PR DESCRIPTION
First of three PRs (one per service repo) migrating deploy secrets from 1Password to **consumer Bitwarden Password Manager** (free tier, no project caps). 1P access requires a paid Service Account tier; Bitwarden's `bw` CLI is the free alternative Kamal supports out of the box (`--adapter bitwarden`). Full plan: `~/.claude/plans/cached-doodling-scroll.md`.

> Earlier revision of this PR targeted Bitwarden Secrets Manager (BWS), but BWS Free caps at 3 projects per org — too tight as more services land. Switched to consumer Bitwarden (no item cap).

## Three commits

1. **Snapshot** current 1P-driven `.kamal/secrets` + `.kamal/secrets.beta` as `.1password.example` — verbatim, no behaviour change.
2. **Switch** the active secrets files to the `bitwarden` adapter. Reads a Bitwarden Secure Note item (`quantic-prod` for prod, `quantic-beta` for beta) holding all relevant secrets as custom fields. Authentication via `BW_CLIENTID` + `BW_CLIENTSECRET` (personal API key) and `BW_PASSWORD` (master password for vault unlock).
3. **Workflow + docs**: deploy workflow installs the `bw` CLI via `npm install -g @bitwarden/cli` on each run; env block swapped from `OP_*` to `BW_*`; `env.sample` and README updated.

## Before merging — operator prereqs (covers all 3 repos)

1. Use any personal Bitwarden account (no org needed). Free tier is fine.
2. In your vault, create two **Secure Note** items:
   - `quantic-prod`
   - `quantic-beta`
3. On each item, add the relevant secrets as **custom fields** (text type, hidden-as-password preferred):
   - **prod**: `KAMAL_REGISTRY_PASSWORD`, `RAILS_MASTER_KEY`, `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GEMINI_API_KEY`, `VITE_LOGO_SERVICE_URL`, `VITE_LOGO_SERVICE_API_KEY`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_BOT_HANDLE`, `TELEGRAM_WEBHOOK_SECRET`, plus the logo-service + pulse keys
   - **beta**: same minus telegram + minus pulse's `LOGO_SERVICE_API_KEY`
4. Generate a personal API key: Bitwarden web vault → Account Settings → Security → Keys → "View API Key". Record `client_id` and `client_secret`.
5. Add to **each of the three repos'** GitHub Actions secrets: `BW_CLIENTID`, `BW_CLIENTSECRET`, `BW_PASSWORD` (your master password).
6. Update each repo's local `.env` with the same three values.

## Test plan

- [ ] BWS prereqs done
- [ ] Locally: `bundle exec kamal secrets fetch --adapter bitwarden --from quantic-prod KAMAL_REGISTRY_PASSWORD` returns the value
- [ ] Locally: `bundle exec kamal envify` succeeds end-to-end
- [ ] Merge → auto-deploy to prod runs green; container has `GEMINI_API_KEY` (verify by hitting `/api/v1/radar/insights`) and `TELEGRAM_BOT_TOKEN` (verify the Telegram link still works)
- [ ] Push to beta → auto-deploy to beta runs green

## Rollback

```sh
cp .kamal/secrets.1password.example .kamal/secrets
cp .kamal/secrets.beta.1password.example .kamal/secrets.beta
# Then revert the workflow change manually.
```
1P vault was never touched — secrets are still there.

## Sister PRs

- logo-service: fleveque/logo-service#25
- pulse: fleveque/pulse#34

🤖 Generated with [Claude Code](https://claude.com/claude-code)