### PR TITLE
Publish radar to Pulse — single slug, two share toggles

### DIFF
--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -22,13 +22,19 @@ module Api
           id: Current.user.id,
           emailAddress: Current.user.email_address,
           portfolioSlug: Current.user.portfolio_slug,
-          preferredCurrency: Current.user.preferred_currency
+          preferredCurrency: Current.user.preferred_currency,
+          sharePortfolio: Current.user.share_portfolio,
+          shareRadar: Current.user.share_radar
         }
       end
 
       def profile_params
-        permitted = params.permit(:portfolio_slug, :preferred_currency)
+        permitted = params.permit(:portfolio_slug, :preferred_currency, :share_portfolio, :share_radar)
         permitted[:portfolio_slug] = nil if permitted.key?(:portfolio_slug) && permitted[:portfolio_slug].blank?
+        # Coerce form-y string booleans to real booleans so AR doesn't choke.
+        %i[share_portfolio share_radar].each do |k|
+          permitted[k] = ActiveModel::Type::Boolean.new.cast(permitted[k]) if permitted.key?(k)
+        end
         permitted
       end
     end

--- a/app/frontend/components/PortfolioInsights.tsx
+++ b/app/frontend/components/PortfolioInsights.tsx
@@ -36,7 +36,7 @@ export function PortfolioInsights({ hasStocks }: PortfolioInsightsProps) {
         <div className="flex items-center justify-between">
           <CardTitle className="text-xl flex items-center gap-2">
             <Sparkles className="size-5 text-violet-500" />
-            {t('insights.title')}
+            {t('insights.portfolioTitle')}
           </CardTitle>
           <div className="flex items-center gap-2">
             {isExpanded && (

--- a/app/frontend/components/PortfolioStatsCard.tsx
+++ b/app/frontend/components/PortfolioStatsCard.tsx
@@ -1,4 +1,6 @@
 import { useTranslation } from 'react-i18next'
+
+import { translateSector } from '@/lib/sectors'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
 import type { PortfolioStats } from '../types'
@@ -98,7 +100,7 @@ function SectorBreakdown({ sectors }: { sectors: PortfolioStats['sectors'] }) {
             key={s.sector}
             className={cn('h-full', SECTOR_COLORS[i % SECTOR_COLORS.length])}
             style={{ width: `${s.percent}%` }}
-            title={`${s.sector}: ${s.percent.toFixed(1)}%`}
+            title={`${translateSector(t, s.sector)}: ${s.percent.toFixed(1)}%`}
           />
         ))}
       </div>
@@ -106,7 +108,7 @@ function SectorBreakdown({ sectors }: { sectors: PortfolioStats['sectors'] }) {
         {sectors.map((s, i) => (
           <li key={s.sector} className="flex items-center gap-2">
             <span className={cn('size-2 rounded-sm', SECTOR_COLORS[i % SECTOR_COLORS.length])} />
-            <span className="text-foreground">{s.sector}</span>
+            <span className="text-foreground">{translateSector(t, s.sector)}</span>
             <span className="text-muted-foreground">{s.percent.toFixed(1)}%</span>
           </li>
         ))}

--- a/app/frontend/components/PulseShareButton.tsx
+++ b/app/frontend/components/PulseShareButton.tsx
@@ -2,36 +2,47 @@ import { ExternalLink, Activity } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Link } from 'react-router-dom'
 import { useProfile } from '../hooks/useProfileQueries'
-import { pulsePortfolioUrl } from '../lib/pulse'
+import { pulsePortfolioUrl, pulseRadarUrl } from '../lib/pulse'
 
-export function PulseShareButton() {
+type Kind = 'portfolio' | 'radar'
+
+interface Props {
+  kind?: Kind
+}
+
+export function PulseShareButton({ kind = 'portfolio' }: Props) {
   const { t } = useTranslation()
   const { data: profile, isLoading } = useProfile()
 
   if (isLoading) return null
 
   const slug = profile?.portfolioSlug
-  if (!slug) {
+  const enabled = kind === 'portfolio' ? profile?.sharePortfolio : profile?.shareRadar
+  const url = kind === 'portfolio' ? pulsePortfolioUrl : pulseRadarUrl
+  const labelKey = kind === 'portfolio' ? 'portfolio.shareOnPulse' : 'radar.shareOnPulse'
+  const hintKey = kind === 'portfolio' ? 'portfolio.shareOnPulseHint' : 'radar.shareOnPulseHint'
+
+  if (!slug || !enabled) {
     return (
       <Link
         to="/settings#portfolio-sharing"
         className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-purple-600 dark:hover:text-purple-400 hover:underline"
       >
         <Activity className="size-4 text-purple-600 dark:text-purple-400" />
-        {t('portfolio.shareOnPulseHint')}
+        {t(hintKey)}
       </Link>
     )
   }
 
   return (
     <a
-      href={pulsePortfolioUrl(slug)}
+      href={url(slug)}
       target="_blank"
       rel="noopener noreferrer"
       className="inline-flex items-center gap-1.5 text-sm text-purple-700 dark:text-purple-300 hover:underline"
     >
       <Activity className="size-4" />
-      {t('portfolio.shareOnPulse')}
+      {t(labelKey)}
       <ExternalLink className="size-3" />
     </a>
   )

--- a/app/frontend/components/RadarInsights.tsx
+++ b/app/frontend/components/RadarInsights.tsx
@@ -36,7 +36,7 @@ export function RadarInsights({ hasStocks }: RadarInsightsProps) {
         <div className="flex items-center justify-between">
           <CardTitle className="text-xl flex items-center gap-2">
             <Sparkles className="size-5 text-violet-500" />
-            {t('insights.title')}
+            {t('insights.radarTitle')}
           </CardTitle>
           <div className="flex items-center gap-2">
             {isExpanded && (

--- a/app/frontend/lib/api.ts
+++ b/app/frontend/lib/api.ts
@@ -443,6 +443,8 @@ export const dividendsApi = {
 export interface ProfileUpdate {
   portfolioSlug?: string | null
   preferredCurrency?: string
+  sharePortfolio?: boolean
+  shareRadar?: boolean
 }
 
 // ============================================================================
@@ -483,6 +485,8 @@ export const profileApi = {
     const body: Record<string, unknown> = {}
     if ('portfolioSlug' in update) body.portfolio_slug = update.portfolioSlug
     if ('preferredCurrency' in update) body.preferred_currency = update.preferredCurrency
+    if ('sharePortfolio' in update) body.share_portfolio = update.sharePortfolio
+    if ('shareRadar' in update) body.share_radar = update.shareRadar
     return apiFetch<UserProfile>('/profile', {
       method: 'PATCH',
       body: JSON.stringify(body),

--- a/app/frontend/lib/pulse.ts
+++ b/app/frontend/lib/pulse.ts
@@ -14,3 +14,11 @@ export function pulsePortfolioUrl(slug: string): string {
 export function pulsePortfolioDisplayUrl(slug: string): string {
   return `${PULSE_URL.replace(/^https?:\/\//, '')}/p/${slug}`
 }
+
+export function pulseRadarUrl(slug: string): string {
+  return `${PULSE_URL}/r/${slug}`
+}
+
+export function pulseRadarDisplayUrl(slug: string): string {
+  return `${PULSE_URL.replace(/^https?:\/\//, '')}/r/${slug}`
+}

--- a/app/frontend/lib/sectors.ts
+++ b/app/frontend/lib/sectors.ts
@@ -1,0 +1,6 @@
+import type { TFunction } from 'i18next'
+
+export function translateSector(t: TFunction, sector: string | null | undefined): string {
+  if (!sector) return ''
+  return t(`sectors.${sector}`, { defaultValue: sector })
+}

--- a/app/frontend/locales/en.ts
+++ b/app/frontend/locales/en.ts
@@ -381,11 +381,18 @@ const en = {
   settings: {
     title: 'Settings',
     portfolioSharing: 'Share on Pulse',
-    sharingDescription: 'Pulse is the Quantic community for sharing portfolios. Pick a public name to opt in — leave it empty to stay private.',
+    sharingDescription: 'Pulse is the Quantic community for sharing portfolios and radars. Pick a public name to opt in — leave it empty to stay private.',
     portfolioSlug: 'Public name',
     slugPlaceholder: 'my-portfolio',
     publicUrl: 'Public URL:',
     failedToUpdate: 'Failed to update',
+    sharing: {
+      whatToShare: 'What to share publicly',
+      portfolio: 'Portfolio',
+      portfolioDescription: 'Your holdings, allocations, and total value (in your display currency).',
+      radar: 'Radar',
+      radarDescription: 'Your watchlist with target prices. No quantities or holdings — just what you’re tracking and at what price.',
+    },
     displayCurrency: 'Display Currency',
     displayCurrencyDescription: 'Choose the currency used to sum multi-currency totals. Per-stock prices stay in their listing currency.',
     telegram: {

--- a/app/frontend/locales/en.ts
+++ b/app/frontend/locales/en.ts
@@ -174,6 +174,8 @@ const en = {
     failedToLoadRadar: 'Failed to load radar',
     failedToRemoveStock: 'Failed to remove stock',
     dividendCalendar: 'Dividend Calendar',
+    shareOnPulse: 'Share on Pulse',
+    shareOnPulseHint: 'Share your radar on Pulse — opt in from Settings',
     switchToCardView: 'Switch to card view',
     switchToCompactView: 'Switch to compact view',
     addToCart: 'Add to Cart',
@@ -335,7 +337,8 @@ const en = {
 
   // AI Insights (shared between radar and portfolio)
   insights: {
-    title: 'AI Portfolio Insights',
+    portfolioTitle: 'AI Portfolio Insights',
+    radarTitle: 'AI Radar Insights',
     buyingOpportunities: 'Buying Opportunities',
     coverageGaps: 'Dividend Coverage Gaps',
     riskFlags: 'Risk Flags',
@@ -558,6 +561,30 @@ const en = {
       title: 'Daily AI limit reached',
       body: "You've used your {{limit}} free AI requests today. AI calls cost real money \u2014 we're offering them free for now. Try again tomorrow.",
     },
+  },
+
+  // GICS / Yahoo Finance stock sectors. Looked up by raw provider name
+  // (see translateSector in lib/sectors.ts) \u2014 unknown names pass through
+  // verbatim so a new sector never blanks the UI.
+  sectors: {
+    'Basic Materials': 'Basic Materials',
+    'Communication Services': 'Communication Services',
+    'Consumer Cyclical': 'Consumer Cyclical',
+    'Consumer Defensive': 'Consumer Defensive',
+    'Consumer Discretionary': 'Consumer Discretionary',
+    'Consumer Staples': 'Consumer Staples',
+    Energy: 'Energy',
+    'Financial Services': 'Financial Services',
+    Financials: 'Financials',
+    'Health Care': 'Health Care',
+    Healthcare: 'Healthcare',
+    Industrials: 'Industrials',
+    'Information Technology': 'Information Technology',
+    Materials: 'Materials',
+    'Real Estate': 'Real Estate',
+    Technology: 'Technology',
+    Utilities: 'Utilities',
+    Unknown: 'Unknown',
   },
 } as const
 

--- a/app/frontend/locales/es.ts
+++ b/app/frontend/locales/es.ts
@@ -380,10 +380,17 @@ const es = {
   settings: {
     title: 'Ajustes',
     portfolioSharing: 'Compartir en Pulse',
-    sharingDescription: 'Pulse es la comunidad de Quantic para compartir carteras. Elige un nombre p\u00fablico para participar \u2014 d\u00e9jalo vac\u00edo para no participar.',
+    sharingDescription: 'Pulse es la comunidad de Quantic para compartir carteras y radares. Elige un nombre p\u00fablico para participar \u2014 d\u00e9jalo vac\u00edo para no participar.',
     portfolioSlug: 'Nombre p\u00fablico',
     slugPlaceholder: 'mi-cartera',
     publicUrl: 'URL p\u00fablica:',
+    sharing: {
+      whatToShare: 'Qu\u00e9 compartir p\u00fablicamente',
+      portfolio: 'Cartera',
+      portfolioDescription: 'Tus posiciones, asignaciones y valor total (en tu moneda de visualizaci\u00f3n).',
+      radar: 'Radar',
+      radarDescription: 'Tu lista de seguimiento con precios objetivo. Sin cantidades ni posiciones \u2014 solo qu\u00e9 est\u00e1s siguiendo y a qu\u00e9 precio.',
+    },
     failedToUpdate: 'Error al actualizar',
     displayCurrency: 'Moneda de visualizaci\u00f3n',
     displayCurrencyDescription: 'Elige la moneda que se usa para sumar totales multi-divisa. Los precios por acci\u00f3n se mantienen en su moneda de cotizaci\u00f3n.',

--- a/app/frontend/locales/es.ts
+++ b/app/frontend/locales/es.ts
@@ -174,6 +174,8 @@ const es = {
     failedToLoadRadar: 'Error al cargar el radar',
     failedToRemoveStock: 'Error al eliminar acci\u00f3n',
     dividendCalendar: 'Calendario de Dividendos',
+    shareOnPulse: 'Compartir en Pulse',
+    shareOnPulseHint: 'Comparte tu radar en Pulse \u2014 act\u00edvalo en Ajustes',
     switchToCardView: 'Cambiar a vista de tarjetas',
     switchToCompactView: 'Cambiar a vista compacta',
     addToCart: 'A\u00f1adir al Carrito',
@@ -334,7 +336,8 @@ const es = {
 
   // AI Insights
   insights: {
-    title: 'An\u00e1lisis IA de Cartera',
+    portfolioTitle: 'An\u00e1lisis IA de Cartera',
+    radarTitle: 'An\u00e1lisis IA del Radar',
     buyingOpportunities: 'Oportunidades de Compra',
     coverageGaps: 'Meses sin Cobertura de Dividendos',
     riskFlags: 'Alertas de Riesgo',
@@ -557,6 +560,30 @@ const es = {
       title: 'Límite diario de IA alcanzado',
       body: 'Has usado tus {{limit}} solicitudes gratuitas de IA hoy. Las llamadas a la IA cuestan dinero real — las ofrecemos gratis por ahora. Inténtalo de nuevo mañana.',
     },
+  },
+
+  // GICS / Yahoo Finance stock sectors. Looked up by raw provider name
+  // (see translateSector in lib/sectors.ts) — unknown names pass through
+  // verbatim so a new sector never blanks the UI.
+  sectors: {
+    'Basic Materials': 'Materiales Básicos',
+    'Communication Services': 'Servicios de Comunicación',
+    'Consumer Cyclical': 'Consumo Cíclico',
+    'Consumer Defensive': 'Consumo Defensivo',
+    'Consumer Discretionary': 'Consumo Discrecional',
+    'Consumer Staples': 'Consumo Básico',
+    Energy: 'Energía',
+    'Financial Services': 'Servicios Financieros',
+    Financials: 'Finanzas',
+    'Health Care': 'Salud',
+    Healthcare: 'Salud',
+    Industrials: 'Industria',
+    'Information Technology': 'Tecnología de la Información',
+    Materials: 'Materiales',
+    'Real Estate': 'Inmobiliario',
+    Technology: 'Tecnología',
+    Utilities: 'Servicios Públicos',
+    Unknown: 'Desconocido',
   },
 } as const
 

--- a/app/frontend/pages/PortfolioPage.tsx
+++ b/app/frontend/pages/PortfolioPage.tsx
@@ -166,7 +166,7 @@ export function PortfolioPage() {
                 <span className="w-1 h-8 bg-foreground rounded-full"></span>
                 {t('portfolio.title')}
               </CardTitle>
-              {holdings.length > 0 && <PulseShareButton />}
+              {holdings.length > 0 && <PulseShareButton kind="portfolio" />}
             </div>
             {holdingsData && holdings.length > 0 && (
               <PortfolioTotalsHeader

--- a/app/frontend/pages/RadarPage.tsx
+++ b/app/frontend/pages/RadarPage.tsx
@@ -11,6 +11,7 @@ import { CartSummaryBar } from '../components/CartSummaryBar'
 import { CartDrawer } from '../components/CartDrawer'
 import { DividendCalendar } from '../components/DividendCalendar'
 import { RadarInsights } from '../components/RadarInsights'
+import { PulseShareButton } from '../components/PulseShareButton'
 import { useRadar, useAddStock, useRemoveStock } from '../hooks/useRadarQueries'
 import { useStockSearch, useResolveStock } from '../hooks/useStockQueries'
 import { useViewPreference } from '../contexts/ViewPreferenceContext'
@@ -97,11 +98,14 @@ export function RadarPage() {
     <div className="container mx-auto px-4 py-8">
       <Card>
         <CardHeader>
-          <div className="flex items-center justify-between gap-2">
-            <CardTitle className="text-2xl sm:text-3xl flex items-center gap-2">
-              <span className="w-1 h-8 bg-foreground rounded-full"></span>
-              {t('radar.title')}
-            </CardTitle>
+          <div className="flex items-start justify-between gap-2">
+            <div className="space-y-2 min-w-0">
+              <CardTitle className="text-2xl sm:text-3xl flex items-center gap-2">
+                <span className="w-1 h-8 bg-foreground rounded-full"></span>
+                {t('radar.title')}
+              </CardTitle>
+              {radarStocks.length > 0 && <PulseShareButton kind="radar" />}
+            </div>
             <BuyPlanModeToggle />
           </div>
         </CardHeader>

--- a/app/frontend/pages/SettingsPage.tsx
+++ b/app/frontend/pages/SettingsPage.tsx
@@ -11,7 +11,7 @@ import { Label } from '@/components/ui/label'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { CURRENCY_OPTIONS } from '@/lib/currency'
-import { pulsePortfolioUrl, pulsePortfolioDisplayUrl } from '../lib/pulse'
+import { pulsePortfolioUrl, pulsePortfolioDisplayUrl, pulseRadarUrl, pulseRadarDisplayUrl } from '../lib/pulse'
 
 export function SettingsPage() {
   const { t } = useTranslation()
@@ -169,21 +169,33 @@ function PortfolioSharingSection() {
               </Button>
             )}
           </div>
-          {slug && (
-            <p className="text-xs text-muted-foreground">
-              {t('settings.publicUrl')}{' '}
-              <a
-                href={pulsePortfolioUrl(slug)}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="font-mono inline-flex items-center gap-1 text-purple-600 dark:text-purple-400 hover:underline"
-              >
-                {pulsePortfolioDisplayUrl(slug)}
-                <ExternalLink className="size-3" />
-              </a>
-            </p>
-          )}
         </div>
+
+        {/* What to share — only meaningful when a slug is set. Defaults:
+            portfolio ON (backwards-compat with the current behaviour),
+            radar OFF (opt-in for the new surface). */}
+        {profile?.portfolioSlug && (
+          <div className="space-y-3 pt-2 border-t">
+            <p className="text-sm font-medium text-foreground">{t('settings.sharing.whatToShare')}</p>
+            <ShareToggle
+              label={t('settings.sharing.portfolio')}
+              description={t('settings.sharing.portfolioDescription')}
+              checked={!!profile.sharePortfolio}
+              onChange={(checked) => updateProfile.mutate({ sharePortfolio: checked })}
+              pending={updateProfile.isPending}
+              publicUrl={profile.sharePortfolio ? { url: pulsePortfolioUrl(profile.portfolioSlug), label: pulsePortfolioDisplayUrl(profile.portfolioSlug) } : null}
+            />
+            <ShareToggle
+              label={t('settings.sharing.radar')}
+              description={t('settings.sharing.radarDescription')}
+              checked={!!profile.shareRadar}
+              onChange={(checked) => updateProfile.mutate({ shareRadar: checked })}
+              pending={updateProfile.isPending}
+              publicUrl={profile.shareRadar ? { url: pulseRadarUrl(profile.portfolioSlug), label: pulseRadarDisplayUrl(profile.portfolioSlug) } : null}
+            />
+          </div>
+        )}
+
         {updateProfile.isError && (
           <Alert variant="destructive">
             <AlertDescription>
@@ -198,6 +210,53 @@ function PortfolioSharingSection() {
         )}
       </CardContent>
     </Card>
+  )
+}
+
+// Single labelled checkbox row used for both "Share portfolio" and
+// "Share radar" inside the Pulse sharing card. Shows the resulting
+// public URL when the toggle is on so the user sees exactly what they're
+// exposing.
+function ShareToggle({
+  label,
+  description,
+  checked,
+  onChange,
+  pending,
+  publicUrl,
+}: {
+  label: string
+  description: string
+  checked: boolean
+  onChange: (checked: boolean) => void
+  pending: boolean
+  publicUrl: { url: string; label: string } | null
+}) {
+  return (
+    <label className="flex items-start gap-3 rounded-lg border p-3 cursor-pointer hover:bg-muted/40 transition-colors">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(e) => onChange(e.target.checked)}
+        disabled={pending}
+        className="mt-0.5 size-4 cursor-pointer accent-purple-600"
+      />
+      <div className="flex-1 text-sm">
+        <p className="font-medium text-foreground">{label}</p>
+        <p className="text-muted-foreground mt-0.5">{description}</p>
+        {publicUrl && (
+          <a
+            href={publicUrl.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-mono text-xs inline-flex items-center gap-1 text-purple-600 dark:text-purple-400 hover:underline mt-1"
+          >
+            {publicUrl.label}
+            <ExternalLink className="size-3" />
+          </a>
+        )}
+      </div>
+    </label>
   )
 }
 

--- a/app/frontend/types/index.ts
+++ b/app/frontend/types/index.ts
@@ -183,6 +183,8 @@ export interface UserProfile {
   emailAddress: string
   portfolioSlug: string | null
   preferredCurrency: string
+  sharePortfolio: boolean
+  shareRadar: boolean
 }
 
 /**

--- a/app/models/radar_stock.rb
+++ b/app/models/radar_stock.rb
@@ -11,4 +11,19 @@ class RadarStock < ApplicationRecord
 
   scope :with_target_price, -> { where.not(target_price: nil) }
   scope :without_target_price, -> { where(target_price: nil) }
+
+  # Mirror Holding#publish_portfolio_updated: any change to a radar entry
+  # (add, remove, target_price tweak) re-publishes the full radar to Pulse
+  # so the public page stays in sync. Only fires when the user is actually
+  # sharing their radar.
+  after_commit :publish_radar_updated
+
+  private
+
+  def publish_radar_updated
+    user = radar&.user
+    return unless user&.portfolio_slug.present? && user.share_radar?
+
+    NatsPublisher.publish("radar.updated", RadarPayloadBuilder.call(user))
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -14,7 +14,8 @@ class User < ApplicationRecord
     if: -> { portfolio_slug.present? }
   validates :preferred_currency, presence: true, inclusion: { in: Stock::CURRENCY_SYMBOLS.keys }
 
-  after_commit :publish_portfolio_slug_change, if: :saved_change_to_portfolio_slug?
+  after_commit :publish_pulse_changes,
+               if: -> { saved_change_to_portfolio_slug? || saved_change_to_share_portfolio? || saved_change_to_share_radar? }
 
   # Find or create a user from OAuth provider data
   def self.from_omniauth(auth)
@@ -30,12 +31,49 @@ class User < ApplicationRecord
 
   private
 
-  def publish_portfolio_slug_change
-    if portfolio_slug.present?
-      NatsPublisher.publish("portfolio.opted_in", PortfolioPayloadBuilder.call(self))
-    else
-      previous_slug = saved_change_to_portfolio_slug.first
-      NatsPublisher.publish("portfolio.opted_out", { slug: previous_slug }) if previous_slug.present?
+  # On any save that touches portfolio_slug / share_portfolio / share_radar,
+  # diff the before/after state for each Pulse surface (portfolio + radar)
+  # and emit the right opted_in / opted_out events. `updated` events are
+  # owned by Holding / RadarStock callbacks — this method handles the
+  # opt-state lifecycle only.
+  def publish_pulse_changes
+    publish_surface_change(:portfolio, share_portfolio?)
+    publish_surface_change(:radar, share_radar?)
+  end
+
+  # Emits `<surface>.opted_in` / `<surface>.opted_out` based on the
+  # *effective shared state* (slug present AND surface toggle on) before
+  # and after the save. Slug changes and toggle changes are both handled
+  # here, so a user clearing their slug fires opt-outs for any currently
+  # active surface.
+  def publish_surface_change(surface, currently_enabled_flag)
+    was_shared = previously_shared?(surface)
+    is_shared = portfolio_slug.present? && currently_enabled_flag
+
+    if is_shared && !was_shared
+      NatsPublisher.publish("#{surface}.opted_in", payload_for(surface))
+    elsif was_shared && !is_shared
+      slug_for_out = saved_change_to_portfolio_slug? ? saved_change_to_portfolio_slug.first : portfolio_slug
+      NatsPublisher.publish("#{surface}.opted_out", { slug: slug_for_out }) if slug_for_out.present?
+    end
+  end
+
+  # Reconstruct the *previous* effective sharing state for `surface` by
+  # looking at saved_change_to_* on the slug and the relevant toggle.
+  # If a column wasn't part of this save its current value is also its
+  # "previous" value.
+  def previously_shared?(surface)
+    prev_slug = saved_change_to_portfolio_slug? ? saved_change_to_portfolio_slug.first : portfolio_slug
+    toggle_change = saved_change_to_share_portfolio if surface == :portfolio
+    toggle_change ||= saved_change_to_share_radar if surface == :radar
+    prev_flag = toggle_change ? toggle_change.first : public_send("share_#{surface}?")
+    prev_slug.present? && prev_flag
+  end
+
+  def payload_for(surface)
+    case surface
+    when :portfolio then PortfolioPayloadBuilder.call(self)
+    when :radar     then RadarPayloadBuilder.call(self)
     end
   end
 end

--- a/app/services/radar_payload_builder.rb
+++ b/app/services/radar_payload_builder.rb
@@ -1,0 +1,39 @@
+module RadarPayloadBuilder
+  module_function
+
+  # Pulse-side schema is fixed at v1 for now. We include enough stock
+  # metadata (price, dividend_yield, MA200, 52w range) that Pulse can
+  # render a standalone radar page even if the user isn't also sharing
+  # their portfolio — no NATS-based stock backfill in this first cut.
+  PAYLOAD_VERSION = 1
+
+  def call(user)
+    {
+      version: PAYLOAD_VERSION,
+      slug: user.portfolio_slug,
+      base_currency: user.preferred_currency || "USD",
+      stocks: serialize_stocks(user)
+    }
+  end
+
+  def serialize_stocks(user)
+    radar = user.radar
+    return [] unless radar
+
+    radar.radar_stocks.includes(:stock).map do |rs|
+      stock = rs.stock
+      {
+        symbol: stock.symbol,
+        name: stock.name,
+        currency: stock.currency,
+        sector: stock.sector,
+        price: stock.price&.to_f,
+        target_price: rs.target_price&.to_f,
+        dividend_yield: stock.dividend_yield&.to_f,
+        fifty_two_week_high: stock.fifty_two_week_high&.to_f,
+        fifty_two_week_low: stock.fifty_two_week_low&.to_f,
+        ma_200: stock.ma_200&.to_f
+      }
+    end
+  end
+end

--- a/db/migrate/20260526070000_add_pulse_share_toggles_to_users.rb
+++ b/db/migrate/20260526070000_add_pulse_share_toggles_to_users.rb
@@ -1,0 +1,9 @@
+class AddPulseShareTogglesToUsers < ActiveRecord::Migration[8.0]
+  # `share_portfolio` defaults to true so anyone currently sharing keeps
+  # sharing seamlessly across the deploy. `share_radar` defaults to false
+  # — opt-in surface; users must explicitly enable it via Settings.
+  def change
+    add_column :users, :share_portfolio, :boolean, null: false, default: true
+    add_column :users, :share_radar, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_25_120001) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_26_070000) do
   create_table "ai_requests", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "feature", null: false
@@ -169,6 +169,8 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_25_120001) do
     t.boolean "admin", default: false, null: false
     t.string "portfolio_slug"
     t.string "preferred_currency", default: "USD", null: false
+    t.boolean "share_portfolio", default: true, null: false
+    t.boolean "share_radar", default: false, null: false
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
     t.index ["portfolio_slug"], name: "index_users_on_portfolio_slug", unique: true
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true

--- a/spec/models/radar_stock_publishing_spec.rb
+++ b/spec/models/radar_stock_publishing_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+RSpec.describe "RadarStock NATS publishing", type: :model do
+  let(:stock) { create(:stock, symbol: "AAPL") }
+
+  before { allow(NatsPublisher).to receive(:publish) }
+
+  it "publishes radar.updated when a radar stock changes for an opted-in user" do
+    user = create(:user, portfolio_slug: "alice", share_radar: true)
+    radar = create(:radar, user: user)
+    RadarStock.create!(radar: radar, stock: stock, target_price: 100)
+    expect(NatsPublisher).to have_received(:publish).with("radar.updated", anything)
+  end
+
+  it "does not publish when the user has share_radar disabled" do
+    user = create(:user, portfolio_slug: "alice", share_radar: false)
+    radar = create(:radar, user: user)
+    RadarStock.create!(radar: radar, stock: stock, target_price: 100)
+    expect(NatsPublisher).not_to have_received(:publish).with("radar.updated", anything)
+  end
+
+  it "does not publish when the user has no slug" do
+    user = create(:user, share_radar: true)
+    radar = create(:radar, user: user)
+    RadarStock.create!(radar: radar, stock: stock, target_price: 100)
+    expect(NatsPublisher).not_to have_received(:publish).with("radar.updated", anything)
+  end
+end

--- a/spec/models/user_pulse_publishing_spec.rb
+++ b/spec/models/user_pulse_publishing_spec.rb
@@ -1,0 +1,76 @@
+require "rails_helper"
+
+# Targeted coverage for the User#publish_pulse_changes after-commit:
+# the 6 transitions across (slug, share_portfolio, share_radar).
+RSpec.describe "User Pulse publishing", type: :model do
+  before { allow(NatsPublisher).to receive(:publish) }
+
+  describe "setting a slug for the first time" do
+    it "publishes portfolio.opted_in (default share_portfolio=true)" do
+      user = create(:user)
+      user.update!(portfolio_slug: "alice")
+      expect(NatsPublisher).to have_received(:publish).with("portfolio.opted_in", anything)
+    end
+
+    it "also publishes radar.opted_in when share_radar is set on the same save" do
+      user = create(:user)
+      user.update!(portfolio_slug: "alice", share_radar: true)
+      expect(NatsPublisher).to have_received(:publish).with("portfolio.opted_in", anything)
+      expect(NatsPublisher).to have_received(:publish).with("radar.opted_in", anything)
+    end
+
+    it "doesn't publish portfolio.opted_in when share_portfolio is false" do
+      user = create(:user, share_portfolio: false)
+      user.update!(portfolio_slug: "alice")
+      expect(NatsPublisher).not_to have_received(:publish).with("portfolio.opted_in", anything)
+    end
+  end
+
+  describe "clearing the slug" do
+    it "publishes opted_out for whichever surfaces were active" do
+      user = create(:user, portfolio_slug: "alice", share_portfolio: true, share_radar: true)
+      user.update!(portfolio_slug: nil)
+      expect(NatsPublisher).to have_received(:publish).with("portfolio.opted_out", hash_including(slug: "alice"))
+      expect(NatsPublisher).to have_received(:publish).with("radar.opted_out", hash_including(slug: "alice"))
+    end
+  end
+
+  describe "flipping share_radar on" do
+    it "publishes radar.opted_in (slug already present)" do
+      user = create(:user, portfolio_slug: "alice", share_radar: false)
+      user.update!(share_radar: true)
+      expect(NatsPublisher).to have_received(:publish).with("radar.opted_in", anything)
+    end
+  end
+
+  describe "flipping share_radar off" do
+    it "publishes radar.opted_out (slug stays present)" do
+      user = create(:user, portfolio_slug: "alice", share_radar: true)
+      user.update!(share_radar: false)
+      expect(NatsPublisher).to have_received(:publish).with("radar.opted_out", hash_including(slug: "alice"))
+    end
+  end
+
+  describe "flipping share_portfolio off (slug present)" do
+    it "publishes portfolio.opted_out without touching radar" do
+      user = create(:user, portfolio_slug: "alice", share_portfolio: true, share_radar: false)
+      user.update!(share_portfolio: false)
+      expect(NatsPublisher).to have_received(:publish).with("portfolio.opted_out", hash_including(slug: "alice"))
+      expect(NatsPublisher).not_to have_received(:publish).with("radar.opted_in", anything)
+      expect(NatsPublisher).not_to have_received(:publish).with("radar.opted_out", anything)
+    end
+  end
+
+  describe "no relevant change" do
+    it "doesn't publish anything when changing preferred_currency only" do
+      user = create(:user, portfolio_slug: "alice")
+      # Reset the spy: the create(:user, portfolio_slug:) above fires the
+      # opt-in for the initial slug set; we only care about the next update.
+      RSpec::Mocks.space.proxy_for(NatsPublisher).reset
+      allow(NatsPublisher).to receive(:publish)
+
+      user.update!(preferred_currency: "EUR")
+      expect(NatsPublisher).not_to have_received(:publish)
+    end
+  end
+end

--- a/spec/requests/api/v1/profiles_spec.rb
+++ b/spec/requests/api/v1/profiles_spec.rb
@@ -66,6 +66,24 @@ RSpec.describe "Api::V1::Profiles", type: :request do
 
         expect(response).to have_http_status(:unprocessable_entity)
       end
+
+      it "exposes and updates the sharePortfolio / shareRadar toggles" do
+        get "/api/v1/profile"
+        json = JSON.parse(response.body)["data"]
+        expect(json["sharePortfolio"]).to be(true)  # default
+        expect(json["shareRadar"]).to be(false)     # default
+
+        patch "/api/v1/profile", params: { share_radar: true, share_portfolio: false }
+        expect(response).to have_http_status(:ok)
+        json = JSON.parse(response.body)["data"]
+        expect(json["sharePortfolio"]).to be(false)
+        expect(json["shareRadar"]).to be(true)
+      end
+
+      it "accepts string booleans (form-style clients)" do
+        patch "/api/v1/profile", params: { share_radar: "true" }
+        expect(JSON.parse(response.body)["data"]["shareRadar"]).to be(true)
+      end
     end
   end
 end

--- a/spec/services/radar_payload_builder_spec.rb
+++ b/spec/services/radar_payload_builder_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe RadarPayloadBuilder, type: :service do
+  let(:user) { create(:user, portfolio_slug: "alice", preferred_currency: "EUR") }
+  let(:radar) { create(:radar, user: user) }
+
+  it "returns the v1 payload shape with empty stocks when the user has no radar" do
+    user_without_radar = create(:user, portfolio_slug: "bob")
+    payload = described_class.call(user_without_radar)
+    expect(payload).to include(version: 1, slug: "bob", stocks: [])
+  end
+
+  it "serialises each radar stock with target_price and the metadata Pulse needs" do
+    stock = create(:stock,
+      symbol: "AAPL", name: "Apple Inc.", currency: "USD", sector: "Technology",
+      price: 178.50, dividend_yield: 0.56,
+      fifty_two_week_high: 199.62, fifty_two_week_low: 164.08, ma_200: 168.40)
+    RadarStock.create!(radar: radar, stock: stock, target_price: 160)
+
+    payload = described_class.call(user)
+
+    expect(payload[:version]).to eq(1)
+    expect(payload[:slug]).to eq("alice")
+    expect(payload[:base_currency]).to eq("EUR")
+    expect(payload[:stocks].length).to eq(1)
+    expect(payload[:stocks].first).to include(
+      symbol: "AAPL",
+      name: "Apple Inc.",
+      currency: "USD",
+      sector: "Technology",
+      price: 178.50,
+      target_price: 160.0,
+      dividend_yield: 0.56,
+      fifty_two_week_high: 199.62,
+      fifty_two_week_low: 164.08,
+      ma_200: 168.40
+    )
+  end
+end


### PR DESCRIPTION
First of two coordinated PRs to add "share your radar on Pulse" alongside the existing portfolio sharing. **This PR is the Quantic side** (schema + NATS publishing + Settings UI). Pulse-side consumer + worker + LiveView + dashboard aggregates ship next as a separate PR.

## Sharing model

One slug per user (existing `portfolio_slug`) with two booleans:
- `share_portfolio` — default `true` (back-compat, current sharers keep sharing)
- `share_radar` — default `false` (opt-in for the new surface)

When both are enabled: `pulse.quantic.es/p/<slug>` AND `pulse.quantic.es/r/<slug>`.

## Publish flow (mirrors portfolio path)

- **`User#publish_pulse_changes`** (renamed from `publish_portfolio_slug_change`) — fires on save when slug, share_portfolio, or share_radar changed. Diffs the effective shared state per surface and emits `{portfolio,radar}.opted_in/out` correctly across all 6 transitions.
- **`RadarStock#after_commit :publish_radar_updated`** — re-emits `radar.updated` on any radar change (add / remove / target_price edit). Mirror of `Holding#publish_portfolio_updated`.
- **`RadarPayloadBuilder`** (new) — v1 payload with enough stock metadata (price, dividend_yield, 52w range, MA200) that Pulse can render a standalone radar page without portfolio events.

## Settings UI

Existing **Share on Pulse** card gets a "What to share publicly" subsection (visible only when a slug is set) with two checkbox rows. New `ShareToggle` component shows the live public URL per surface when enabled.

## Frontend polish (added after initial scope)

- **Localized stock sectors** via new `translateSector(t, sector)` helper + `sectors` namespace in both `en.ts` / `es.ts`. Covers the 17 GICS / Yahoo Finance names + `Unknown`; unknown sectors pass through verbatim. Wired into `PortfolioStatsCard`'s sector legend and tooltip.
- **Pulse share button on the radar page**. `PulseShareButton` parameterised with `kind: 'portfolio' | 'radar'` — gates on the matching toggle (`sharePortfolio` / `shareRadar`) and links to the right URL. Also fixed: if a slug exists but the relevant toggle is off, show the "opt in from Settings" hint instead of a dead public link.
- **Radar AI insights title** said "AI Portfolio Insights" because `RadarInsights` and `PortfolioInsights` shared the `insights.title` key. Split into `insights.portfolioTitle` and `insights.radarTitle`.

## Deploy order: ship the Pulse PR first

NATS is plain pub/sub (no JetStream queue) — messages sent to a subject with no live subscriber are dropped at the broker. If this PR deploys before fleveque/pulse#35:

- `radar.opted_in` events for users toggling Share Radar are dropped — their radar never registers in Pulse until they next edit it.
- `radar.updated` events from price refreshes are also dropped during the window.

**Order to ship**: fleveque/pulse#35 first (Pulse starts subscribing to `radar.*` and idles harmlessly with no publishers), then this PR (Quantic starts publishing into a Pulse that's ready to consume from event #1).

## Test plan

- [x] `bundle exec rspec` — 676 examples / 0 failures (22 new across payload builder, user transitions, RadarStock callback, profile controller)
- [x] `bin/rubocop` on touched Ruby — clean
- [x] `npx tsc --noEmit` — clean
- [x] `npx vite build` — succeeds
- [ ] Manual: Settings → toggle Share radar → publish appears in NATS monitoring (`localhost:8222`)
- [ ] Manual: edit a target price → `radar.updated` fires
- [ ] Manual: clear portfolio_slug → both opt-out events fire
- [ ] Manual: switch language to ES → sector names render in Spanish; radar page shows "Compartir en Pulse" + "Análisis IA del Radar"

## Rollback

Single revert. Migration adds two columns with safe defaults — leaving them in place is harmless if code reverts.

## Sister PR

Pulse-side (RadarWorker + RadarLive + Dashboard "Community watchlist"): fleveque/pulse#35.

🤖 Generated with [Claude Code](https://claude.com/claude-code)