### PR TITLE
Persist user locale on the backend

### DIFF
--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -22,12 +22,13 @@ module Api
           id: Current.user.id,
           emailAddress: Current.user.email_address,
           portfolioSlug: Current.user.portfolio_slug,
-          preferredCurrency: Current.user.preferred_currency
+          preferredCurrency: Current.user.preferred_currency,
+          locale: Current.user.locale
         }
       end
 
       def profile_params
-        permitted = params.permit(:portfolio_slug, :preferred_currency)
+        permitted = params.permit(:portfolio_slug, :preferred_currency, :locale)
         permitted[:portfolio_slug] = nil if permitted.key?(:portfolio_slug) && permitted[:portfolio_slug].blank?
         permitted
       end

--- a/app/frontend/components/LanguageToggle.tsx
+++ b/app/frontend/components/LanguageToggle.tsx
@@ -1,18 +1,30 @@
 import { Globe } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { Button } from '@/components/ui/button'
+import { useProfile, useUpdateProfile } from '../hooks/useProfileQueries'
 
 export function LanguageToggle() {
   const { i18n, t } = useTranslation()
+  const { data: profile } = useProfile()
+  const updateProfile = useUpdateProfile()
 
   const currentLang = i18n.language?.startsWith('es') ? 'es' : 'en'
   const nextLang = currentLang === 'en' ? 'es' : 'en'
+
+  const handleClick = () => {
+    i18n.changeLanguage(nextLang)
+    // Persist to the user's profile so other devices and the Telegram
+    // daily digest pick it up. Anonymous (logged-out) users still get
+    // the localStorage-cached preference from i18next; we only call the
+    // API when there's a profile to update.
+    if (profile) updateProfile.mutate({ locale: nextLang })
+  }
 
   return (
     <Button
       variant="ghost"
       size="sm"
-      onClick={() => i18n.changeLanguage(nextLang)}
+      onClick={handleClick}
       title={t('language.switchLanguage')}
       aria-label={t('language.switchLanguage')}
       className="gap-1.5"

--- a/app/frontend/components/Layout.tsx
+++ b/app/frontend/components/Layout.tsx
@@ -3,6 +3,7 @@ import { Link, NavLink, Outlet, useLocation, useNavigate } from 'react-router-do
 import { Menu } from 'lucide-react'
 import { useTranslation } from 'react-i18next'
 import { useAuth } from '../contexts/AuthContext'
+import { useLocaleSync } from '../hooks/useLocaleSync'
 import { Logo } from './Logo'
 import { ThemeToggle } from './ThemeToggle'
 import { LanguageToggle } from './LanguageToggle'
@@ -31,6 +32,8 @@ export function Layout() {
   const location = useLocation()
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false)
   const { t } = useTranslation()
+
+  useLocaleSync()
 
   // /demo/* is the anonymous "try the product" route. The Layout adapts: nav
   // links point at the demo equivalents, the right-side "Sign in" CTA flips

--- a/app/frontend/hooks/useLocaleSync.ts
+++ b/app/frontend/hooks/useLocaleSync.ts
@@ -1,0 +1,17 @@
+import { useEffect } from 'react'
+import { useTranslation } from 'react-i18next'
+import { useProfile } from './useProfileQueries'
+
+// When a user's profile loads, switch the i18n language to their stored
+// locale so it survives across devices and matches the Telegram daily
+// digest. Anonymous users keep the localStorage-cached preference.
+export function useLocaleSync() {
+  const { i18n } = useTranslation()
+  const { data: profile } = useProfile()
+
+  useEffect(() => {
+    if (!profile?.locale) return
+    const current = i18n.language?.split('-')[0]
+    if (current !== profile.locale) i18n.changeLanguage(profile.locale)
+  }, [profile?.locale, i18n])
+}

--- a/app/frontend/lib/api.ts
+++ b/app/frontend/lib/api.ts
@@ -443,6 +443,7 @@ export const dividendsApi = {
 export interface ProfileUpdate {
   portfolioSlug?: string | null
   preferredCurrency?: string
+  locale?: string
 }
 
 // ============================================================================
@@ -483,6 +484,7 @@ export const profileApi = {
     const body: Record<string, unknown> = {}
     if ('portfolioSlug' in update) body.portfolio_slug = update.portfolioSlug
     if ('preferredCurrency' in update) body.preferred_currency = update.preferredCurrency
+    if ('locale' in update) body.locale = update.locale
     return apiFetch<UserProfile>('/profile', {
       method: 'PATCH',
       body: JSON.stringify(body),

--- a/app/frontend/types/index.ts
+++ b/app/frontend/types/index.ts
@@ -183,6 +183,7 @@ export interface UserProfile {
   emailAddress: string
   portfolioSlug: string | null
   preferredCurrency: string
+  locale: string
 }
 
 /**

--- a/app/jobs/telegram/daily_digest_job.rb
+++ b/app/jobs/telegram/daily_digest_job.rb
@@ -22,11 +22,7 @@ module Telegram
     private
 
     def deliver_for(link)
-      # No per-user locale storage yet — default to English. The handler's
-      # per-message locale detection (Telegram message.from.language_code)
-      # only works for inbound replies; for batched outbound digests we'd
-      # need a stored preference, which is a future iteration.
-      message = DailyDigest.build(user: link.user, locale: "en")
+      message = DailyDigest.build(user: link.user, locale: link.user.locale)
       return if message.blank? # nothing to say today
 
       TelegramBot::Client.send_message(chat_id: link.chat_id, text: message)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,8 @@
 class User < ApplicationRecord
+  # Locales supported by the React frontend (see app/frontend/locales/) and
+  # the Telegram bot (see TelegramBot::Copy). Kept in sync manually.
+  SUPPORTED_LOCALES = %w[en es].freeze
+
   has_secure_password validations: false
   has_many :sessions, dependent: :destroy
   has_many :dividends, dependent: :delete_all
@@ -13,6 +17,7 @@ class User < ApplicationRecord
     format: { with: /\A[a-z0-9][a-z0-9-]{1,38}[a-z0-9]\z/, message: "must be 3-40 lowercase alphanumeric characters or hyphens" },
     if: -> { portfolio_slug.present? }
   validates :preferred_currency, presence: true, inclusion: { in: Stock::CURRENCY_SYMBOLS.keys }
+  validates :locale, presence: true, inclusion: { in: SUPPORTED_LOCALES }
 
   after_commit :publish_portfolio_slug_change, if: :saved_change_to_portfolio_slug?
 

--- a/db/migrate/20260526093000_add_locale_to_users.rb
+++ b/db/migrate/20260526093000_add_locale_to_users.rb
@@ -1,0 +1,5 @@
+class AddLocaleToUsers < ActiveRecord::Migration[8.0]
+  def change
+    add_column :users, :locale, :string, default: "en", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2026_05_25_120001) do
+ActiveRecord::Schema[8.0].define(version: 2026_05_26_093000) do
   create_table "ai_requests", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "feature", null: false
@@ -169,6 +169,9 @@ ActiveRecord::Schema[8.0].define(version: 2026_05_25_120001) do
     t.boolean "admin", default: false, null: false
     t.string "portfolio_slug"
     t.string "preferred_currency", default: "USD", null: false
+    t.boolean "share_portfolio", default: true, null: false
+    t.boolean "share_radar", default: false, null: false
+    t.string "locale", default: "en", null: false
     t.index ["email_address"], name: "index_users_on_email_address", unique: true
     t.index ["portfolio_slug"], name: "index_users_on_portfolio_slug", unique: true
     t.index ["provider", "uid"], name: "index_users_on_provider_and_uid", unique: true

--- a/spec/jobs/telegram/daily_digest_job_spec.rb
+++ b/spec/jobs/telegram/daily_digest_job_spec.rb
@@ -33,6 +33,16 @@ RSpec.describe Telegram::DailyDigestJob, type: :job do
       .with(hash_including(chat_id: "42", text: /KO/))
   end
 
+  it "builds the digest in the user's stored locale" do
+    es_user = create(:user, locale: "es")
+    UserTelegramLink.create!(user: es_user, chat_id: "9", telegram_user_id: "u", linked_at: Time.current, notifications_enabled: true)
+    allow(Telegram::DailyDigest).to receive(:build).and_return("digest")
+
+    described_class.perform_now
+
+    expect(Telegram::DailyDigest).to have_received(:build).with(user: es_user, locale: "es")
+  end
+
   it "doesn't abort the batch if one user's digest raises" do
     user_a = create(:user)
     user_b = create(:user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe User, type: :model do
     it { should validate_uniqueness_of(:portfolio_slug) }
     it { should validate_presence_of(:preferred_currency) }
     it { should validate_inclusion_of(:preferred_currency).in_array(Stock::CURRENCY_SYMBOLS.keys) }
+    it { should validate_presence_of(:locale) }
+    it { should validate_inclusion_of(:locale).in_array(User::SUPPORTED_LOCALES) }
   end
 
   describe 'preferred_currency' do

--- a/spec/requests/api/v1/profiles_spec.rb
+++ b/spec/requests/api/v1/profiles_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe "Api::V1::Profiles", type: :request do
         expect(json["data"]["emailAddress"]).to eq(user.email_address)
         expect(json["data"]["portfolioSlug"]).to be_nil
         expect(json["data"]["preferredCurrency"]).to eq("USD")
+        expect(json["data"]["locale"]).to eq("en")
       end
     end
   end
@@ -63,6 +64,20 @@ RSpec.describe "Api::V1::Profiles", type: :request do
 
       it "rejects an unsupported currency" do
         patch "/api/v1/profile", params: { preferred_currency: "XYZ" }
+
+        expect(response).to have_http_status(:unprocessable_entity)
+      end
+
+      it "updates the locale" do
+        patch "/api/v1/profile", params: { locale: "es" }
+
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body)["data"]["locale"]).to eq("es")
+        expect(user.reload.locale).to eq("es")
+      end
+
+      it "rejects an unsupported locale" do
+        patch "/api/v1/profile", params: { locale: "fr" }
 
         expect(response).to have_http_status(:unprocessable_entity)
       end


### PR DESCRIPTION
## Why

The frontend language picker stored its choice in localStorage only — nothing made it back to the server. As a result the daily Telegram digest always went out in English no matter what the user had picked in the UI (the old comment in `DailyDigestJob#deliver_for` called this out: *"No per-user locale storage yet — default to English"*).

Surfaced when a user with the UI set to ES still received their daily digest in EN.

## What changed

**Backend**
- Migration adds `users.locale` (string, NOT NULL, default `"en"`).
- `User::SUPPORTED_LOCALES = %w[en es]` constant + presence + inclusion validation, matching the pattern used for `preferred_currency`.
- `Api::V1::ProfilesController` returns `locale` and accepts it in PATCH params.
- `Telegram::DailyDigestJob` passes `link.user.locale` instead of the hardcoded `"en"`. Inbound-reply handling is unchanged — `TelegramBot::Handler#normalise_locale` still reads `language_code` off each Telegram message for replies.

**Frontend**
- `UserProfile` + `ProfileUpdate` types extended with `locale`; `profileApi.update` ships it in the body.
- New `useLocaleSync` hook (called once in `Layout`) sets `i18n.language` from `profile.locale` whenever the profile loads — profile is the source of truth across devices, so a fresh login on another browser picks the right language. Anonymous users keep the localStorage fallback that `i18next-browser-languagedetector` already provides.
- `LanguageToggle` calls `updateProfile.mutate({ locale })` on every toggle so the backend always reflects the latest choice.

## Test plan

- [x] `bundle exec rspec` — 666 / 0 (new cases in `user_spec`, `profiles_spec`, `daily_digest_job_spec`)
- [x] `npx tsc --noEmit` — clean
- [x] `bin/rubocop` on touched Ruby — clean
- [ ] Manual: log in, toggle language → `PATCH /api/v1/profile` fires with `{ locale }`; reload page → language persists
- [ ] Manual: log in on a second browser → language reflects the stored preference (overrides localStorage)
- [ ] Manual: with notifications enabled and `locale: "es"`, trigger `Telegram::DailyDigestJob` → digest arrives in Spanish

## Rollback

Single revert. The migration adds a column with a safe default, so leaving it in place is harmless if code reverts.

## Out of scope

- Backfilling existing users — they all default to `"en"`, which matches today's behaviour.
- A dedicated language picker on the Settings page (the toggle in the header is enough for v1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)