### PR TITLE
Fix DividendIncomeMini hidden for users with past dividends

### DIFF
--- a/app/frontend/pages/home/auth/DividendIncomeMini.tsx
+++ b/app/frontend/pages/home/auth/DividendIncomeMini.tsx
@@ -17,15 +17,18 @@ export function DividendIncomeMini() {
 
   const currency = profile?.preferredCurrency ?? 'USD'
 
-  // Aggregate "actual" income across currencies (raw monthly buckets are
-  // per-currency; for the mini view we pick the user's preferred currency
-  // if it's present, otherwise fall back to the first bucket).
+  // The server returns 12 past + 12 future buckets per currency; we only
+  // want the *past* months for this mini (history, not projection). Past
+  // months are exactly the ones where `actual !== null` — that filter is
+  // more robust than slicing by index in case the server window changes.
   const monthly = useMemo(() => {
     if (!chartData) return null
     const buckets = chartData.byCurrency[currency] ?? Object.values(chartData.byCurrency)[0]
     if (!buckets) return null
-    // Last 12 months only.
-    return buckets.slice(-12)
+    const past = buckets.filter((b) => b.actual !== null)
+    // Keep the most recent 12 months — handles wider windows
+    // (e.g. range=full) gracefully.
+    return past.slice(-12)
   }, [chartData, currency])
 
   if (isLoading) return null


### PR DESCRIPTION
Reported in prod after #174 merged.

## Bug

User has several recorded dividends but the `DividendIncomeMini` card never renders on the dashboard.

## Root cause

`/dividends/chart_data` returns **24 buckets per currency**: 12 past + 12 future. Past months carry `actual` (paid), future months carry `projected` (forecasted from holdings).

My code did `buckets.slice(-12)` — grabbing the *last* 12 entries, which is the **future** half (current month + 11 forward). Their `actual` is mostly `null`, so the empty-state guard `total === 0` fired and the card hid itself, unless the user happened to have a payment in the current month.

## Fix

Filter to past-only entries (`actual !== null`) and take the last 12. Robust to wider server windows (e.g. `range=full` opens the window further).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [ ] Manual: logged in with an account that has historical dividends → `DividendIncomeMini` renders with this-month total + 12-bar sparkline
- [ ] Manual: empty account (no recorded dividends) → mini stays hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)