### PR TITLE
Add /faq page covering anon + logged-in audiences

### DIFF
--- a/app/frontend/components/App.tsx
+++ b/app/frontend/components/App.tsx
@@ -29,6 +29,7 @@ import PortfolioPage from '../pages/PortfolioPage'
 import DividendsPage from '../pages/DividendsPage'
 import SettingsPage from '../pages/SettingsPage'
 import DemoPage from '../pages/DemoPage'
+import FaqPage from '../pages/FaqPage'
 
 /**
  * QueryClient Configuration
@@ -70,6 +71,7 @@ function App() {
                     <Route path="/" element={<HomePage />} />
                     <Route path="/login" element={<LoginPage />} />
                     <Route path="/signup" element={<SignUpPage />} />
+                    <Route path="/faq" element={<FaqPage />} />
                     <Route element={<ProtectedRoute />}>
                       <Route path="/radar" element={<RadarPage />} />
                       <Route path="/portfolio" element={<PortfolioPage />} />

--- a/app/frontend/components/Layout.tsx
+++ b/app/frontend/components/Layout.tsx
@@ -74,6 +74,8 @@ export function Layout() {
                 </>
               )}
 
+              <NavLink to="/faq" className={navLinkClass}>{t('nav.faq')}</NavLink>
+
               {isAuthenticated && user?.admin && (
                 <NavLink to="/admin" className={navLinkClass}>{t('nav.admin')}</NavLink>
               )}
@@ -134,6 +136,8 @@ export function Layout() {
                 )}
               </>
             )}
+
+            <NavLink to="/faq" className={mobileNavLinkClass} onClick={closeMobile}>{t('nav.faq')}</NavLink>
 
             {isAuthenticated && user?.admin && (
               <NavLink to="/admin" className={mobileNavLinkClass} onClick={closeMobile}>{t('nav.admin')}</NavLink>

--- a/app/frontend/components/Layout.tsx
+++ b/app/frontend/components/Layout.tsx
@@ -188,6 +188,10 @@ export function Layout() {
                 >
                   Francesc Leveque
                 </a>
+                {' · '}
+                <Link to="/faq" className="hover:underline">
+                  {t('footer.faq')}
+                </Link>
               </p>
             </div>
           </div>

--- a/app/frontend/locales/en.ts
+++ b/app/frontend/locales/en.ts
@@ -148,7 +148,7 @@ const en = {
     ai: {
       model: {
         q: 'Which AI model do you use?',
-        a: "We currently use Anthropic's Claude (Haiku for stock summaries, Sonnet for portfolio and radar insights). The service is provider-agnostic and can be swapped without affecting the UI.",
+        a: "We currently use Google's Gemini (2.5 Flash). The integration is provider-agnostic — we can swap to OpenAI or Anthropic depending on what each task needs, without affecting the UI.",
       },
       limit: {
         q: 'Is there an AI usage limit?',

--- a/app/frontend/locales/en.ts
+++ b/app/frontend/locales/en.ts
@@ -6,6 +6,7 @@ const en = {
     portfolio: 'Portfolio',
     dividends: 'Dividends',
     settings: 'Settings',
+    faq: 'FAQ',
     admin: 'Admin',
     menu: 'Menu',
     navigationMenu: 'Navigation menu',

--- a/app/frontend/locales/en.ts
+++ b/app/frontend/locales/en.ts
@@ -64,7 +64,7 @@ const en = {
   footer: {
     builtWith: 'Built with Ruby on Rails, React, TypeScript, and Tailwind CSS',
     disclaimer: 'The information on Quantic is provided for informational and educational purposes only. It is general in nature, does not take into account your personal financial situation, and does not constitute investment, financial, tax, or legal advice — nor a recommendation to buy or sell any security. Investing involves risk, including possible loss of principal; past performance is not a reliable indicator of future results. Market data comes from third-party providers and may be delayed or inaccurate. Before making any investment decision, consider your objectives, time horizon, risk tolerance, and diversification, and consult a qualified financial professional. Quantic is not a registered investment adviser or broker-dealer.',
-    faq: 'FAQ',
+    faq: 'Frequently Asked Questions',
   },
 
   // FAQ Page

--- a/app/frontend/locales/en.ts
+++ b/app/frontend/locales/en.ts
@@ -63,6 +63,140 @@ const en = {
   footer: {
     builtWith: 'Built with Ruby on Rails, React, TypeScript, and Tailwind CSS',
     disclaimer: 'The information on Quantic is provided for informational and educational purposes only. It is general in nature, does not take into account your personal financial situation, and does not constitute investment, financial, tax, or legal advice — nor a recommendation to buy or sell any security. Investing involves risk, including possible loss of principal; past performance is not a reliable indicator of future results. Market data comes from third-party providers and may be delayed or inaccurate. Before making any investment decision, consider your objectives, time horizon, risk tolerance, and diversification, and consult a qualified financial professional. Quantic is not a registered investment adviser or broker-dealer.',
+    faq: 'FAQ',
+  },
+
+  // FAQ Page
+  faq: {
+    title: 'Frequently Asked Questions',
+    subtitle: "Quick answers to the most common questions about Quantic. Can't find what you need? Open an issue on GitHub.",
+    notFound: {
+      body: "Didn't find your question? We'd love to hear from you.",
+      cta: 'Open an issue on GitHub',
+    },
+    sections: {
+      gettingStarted: 'Getting started',
+      portfolioRadar: 'Portfolio & Radar',
+      dividends: 'Dividends',
+      ai: 'AI insights',
+      pulse: 'Pulse (community sharing)',
+      telegram: 'Telegram bot',
+      dataPrivacy: 'Data & privacy',
+    },
+    gettingStarted: {
+      free: {
+        q: 'Is Quantic free?',
+        a: "Yes. Quantic is free for personal use. We rely on third-party APIs that cost real money (stock data, AI), so heavy automated use may be rate-limited — but everyday investing is free.",
+      },
+      broker: {
+        q: 'Do I need to connect my broker?',
+        a: "No broker connection required. You enter your holdings manually or import dividend transactions from a CSV your broker exports. Your broker credentials never leave your hands.",
+      },
+      tryWithoutSignup: {
+        q: 'Can I try Quantic without signing up?',
+        a: 'Yes. Click "Try a sample portfolio" on the home page to explore a pre-populated demo account. No signup, no email.',
+      },
+      portfolioVsRadar: {
+        q: "What's the difference between Portfolio and Radar?",
+        a: "Your Portfolio is what you actually own — quantities, average prices, real value. Your Radar is your watchlist — stocks you're tracking with optional target prices. The same stock can be in both.",
+      },
+    },
+    portfolioRadar: {
+      addHolding: {
+        q: 'How do I add a holding?',
+        a: 'Go to Portfolio, search for the stock, click Add. Enter quantity and average price. You can add more shares later (the average price updates automatically) or remove holdings entirely.',
+      },
+      multiCurrency: {
+        q: 'Can I track stocks in multiple currencies?',
+        a: 'Yes. Each holding stays in its listing currency. Set a preferred currency in Settings and we convert per-currency totals into a single display total using daily FX rates.',
+      },
+      yoc: {
+        q: 'What does "Yield on Cost" mean?',
+        a: "Yield on Cost = annual dividend per share ÷ your average purchase price × 100. It measures the yield you locked in when you bought, regardless of what the share price has done since.",
+      },
+      targetPrice: {
+        q: "What's a target price?",
+        a: "Your personal buy threshold for a stock — the price at which you'd consider adding it. Set it on a Radar stock and we'll show the gap to the current price (above/below) to flag opportunities.",
+      },
+      communityTarget: {
+        q: 'Where does the "community average target" come from?',
+        a: 'We average the target prices set by all users tracking the same stock. To protect individual targets, we only show the average once at least 3 users have set one.',
+      },
+      score: {
+        q: 'What does the dividend score mean?',
+        a: "A 0–10 score that summarizes a stock's dividend health: payout ratio, dividend growth, yield, and consistency. Higher is better. 7+ is 'Strong', 5–7 'Fair', below 5 'Weak'.",
+      },
+    },
+    dividends: {
+      upcoming: {
+        q: 'How are upcoming dividends calculated?',
+        a: "From each holding's stock data we pull the next ex-dividend date and the expected per-share amount, multiplied by your quantity. The dashboard shows the next 14 days.",
+      },
+      import: {
+        q: 'Can I import dividends from my broker?',
+        a: "Yes. On the Dividends page, click Import. Upload a CSV from your broker; we parse it, show you a preview, and you confirm before anything is saved.",
+      },
+      brokerSupport: {
+        q: 'Which brokers does the import support?',
+        a: "Currently Interactive Brokers and MyInvestor (Spain). Adding a new broker means writing a small parser — open a GitHub issue with a sample CSV and we'll consider it.",
+      },
+      unsupportedBroker: {
+        q: "What if my broker isn't supported?",
+        a: 'Add dividends manually on the Dividends page. Or open a GitHub issue requesting a parser for your broker — include a sample CSV.',
+      },
+    },
+    ai: {
+      model: {
+        q: 'Which AI model do you use?',
+        a: "We currently use Anthropic's Claude (Haiku for stock summaries, Sonnet for portfolio and radar insights). The service is provider-agnostic and can be swapped without affecting the UI.",
+      },
+      limit: {
+        q: 'Is there an AI usage limit?',
+        a: 'Non-admin users get 3 AI requests per day across all features (insights, summaries, Telegram chat). AI calls cost real money; the limit keeps the service free for everyone.',
+      },
+      privacy: {
+        q: 'Is my data sent to the AI provider?',
+        a: "Only the data needed for the prompt — the stocks involved, your targets, your dividends. We never send your email, password, or anything outside the specific request. Prompts are not retained.",
+      },
+    },
+    pulse: {
+      what: {
+        q: 'What is Pulse?',
+        a: 'Pulse is the Quantic community at pulse.quantic.es. Users can opt in to share their portfolio (holdings + sectors) and/or their radar (watchlist + target prices) under a public slug.',
+      },
+      whoSees: {
+        q: 'Who can see my shared portfolio?',
+        a: "Anyone with the URL. Pulse pages are publicly accessible without an account. Don't share if you're not comfortable with that — it's opt-in for exactly this reason.",
+      },
+      optOut: {
+        q: 'How do I stop sharing?',
+        a: 'Settings → Share on Pulse → uncheck the toggle for the surface you want to stop sharing. The data is removed from Pulse immediately.',
+      },
+    },
+    telegram: {
+      connect: {
+        q: 'How do I connect Telegram?',
+        a: 'Settings → Connect Telegram → click "Open Telegram bot". Tap Send in Telegram, then come back here and click Refresh. Your Telegram account is now linked.',
+      },
+      what: {
+        q: 'What can I ask the bot?',
+        a: 'Ask things like "what dividends did I get this month?", "show my radar", "any ex-divs this week?". The bot answers using your real data via AI.',
+      },
+    },
+    dataPrivacy: {
+      stockData: {
+        q: 'Where does stock data come from?',
+        a: 'Stock prices, dividends, ex-div dates, and fundamentals come from Yahoo Finance (with Alpha Vantage as a fallback). Data is cached for 1 hour to stay within free-tier limits.',
+      },
+      accuracy: {
+        q: 'How accurate is the data?',
+        a: "Best-effort. Third-party APIs occasionally serve stale or wrong data, especially on the day of an ex-dividend or right after a split. Always verify against your broker's official statement before acting.",
+      },
+      sell: {
+        q: 'Do you sell my data?',
+        a: "No. Quantic has no advertising, no third-party analytics tracking, and no data sales. We're a one-developer side project, not a data company.",
+      },
+    },
   },
 
   // Home Page

--- a/app/frontend/locales/es.ts
+++ b/app/frontend/locales/es.ts
@@ -6,6 +6,7 @@ const es = {
     portfolio: 'Cartera',
     dividends: 'Dividendos',
     settings: 'Ajustes',
+    faq: 'FAQ',
     admin: 'Admin',
     menu: 'Men\u00fa',
     navigationMenu: 'Men\u00fa de navegaci\u00f3n',

--- a/app/frontend/locales/es.ts
+++ b/app/frontend/locales/es.ts
@@ -64,7 +64,7 @@ const es = {
   footer: {
     builtWith: 'Hecho con Ruby on Rails, React, TypeScript y Tailwind CSS',
     disclaimer: 'La información en Quantic se proporciona únicamente con fines informativos y educativos. Es de carácter general, no tiene en cuenta tu situación financiera personal y no constituye asesoramiento de inversión, financiero, fiscal o legal — ni una recomendación para comprar o vender ningún valor. Invertir conlleva riesgos, incluida la posible pérdida del capital; los resultados pasados no son un indicador fiable de los resultados futuros. Los datos de mercado provienen de proveedores terceros y pueden estar retrasados o ser inexactos. Antes de tomar cualquier decisión de inversión, considera tus objetivos, horizonte temporal, tolerancia al riesgo y diversificación, y consulta a un profesional financiero cualificado. Quantic no es un asesor financiero registrado ni un intermediario bursátil.',
-    faq: 'FAQ',
+    faq: 'Preguntas frecuentes',
   },
 
   // FAQ Page

--- a/app/frontend/locales/es.ts
+++ b/app/frontend/locales/es.ts
@@ -148,7 +148,7 @@ const es = {
     ai: {
       model: {
         q: '¿Qué modelo de IA usáis?',
-        a: 'Actualmente usamos Claude de Anthropic (Haiku para resúmenes de acciones, Sonnet para análisis de cartera y radar). El servicio es agnóstico de proveedor y puede cambiarse sin afectar a la UI.',
+        a: 'Actualmente usamos Gemini de Google (2.5 Flash). La integración es agnóstica de proveedor — podemos cambiar a OpenAI o Anthropic en función de las necesidades de cada tarea, sin afectar a la UI.',
       },
       limit: {
         q: '¿Hay un límite de uso de IA?',

--- a/app/frontend/locales/es.ts
+++ b/app/frontend/locales/es.ts
@@ -63,6 +63,140 @@ const es = {
   footer: {
     builtWith: 'Hecho con Ruby on Rails, React, TypeScript y Tailwind CSS',
     disclaimer: 'La información en Quantic se proporciona únicamente con fines informativos y educativos. Es de carácter general, no tiene en cuenta tu situación financiera personal y no constituye asesoramiento de inversión, financiero, fiscal o legal — ni una recomendación para comprar o vender ningún valor. Invertir conlleva riesgos, incluida la posible pérdida del capital; los resultados pasados no son un indicador fiable de los resultados futuros. Los datos de mercado provienen de proveedores terceros y pueden estar retrasados o ser inexactos. Antes de tomar cualquier decisión de inversión, considera tus objetivos, horizonte temporal, tolerancia al riesgo y diversificación, y consulta a un profesional financiero cualificado. Quantic no es un asesor financiero registrado ni un intermediario bursátil.',
+    faq: 'FAQ',
+  },
+
+  // FAQ Page
+  faq: {
+    title: 'Preguntas frecuentes',
+    subtitle: '¿No encuentras lo que buscas? Abre un issue en GitHub.',
+    notFound: {
+      body: '¿No has encontrado tu pregunta? Cuéntanoslo.',
+      cta: 'Abrir un issue en GitHub',
+    },
+    sections: {
+      gettingStarted: 'Empezar',
+      portfolioRadar: 'Cartera y Radar',
+      dividends: 'Dividendos',
+      ai: 'Análisis con IA',
+      pulse: 'Pulse (compartir con la comunidad)',
+      telegram: 'Bot de Telegram',
+      dataPrivacy: 'Datos y privacidad',
+    },
+    gettingStarted: {
+      free: {
+        q: '¿Quantic es gratis?',
+        a: 'Sí. Quantic es gratis para uso personal. Dependemos de APIs externas con coste real (datos de mercado, IA), por lo que el uso automatizado intensivo puede tener límites — pero el uso diario para invertir es gratuito.',
+      },
+      broker: {
+        q: '¿Necesito conectar mi bróker?',
+        a: 'No hace falta conectar el bróker. Introduces tus posiciones manualmente o importas los dividendos desde un CSV que exportes en tu bróker. Tus credenciales nunca salen de tus manos.',
+      },
+      tryWithoutSignup: {
+        q: '¿Puedo probar Quantic sin registrarme?',
+        a: 'Sí. Haz clic en "Prueba una cartera de ejemplo" en la home para explorar una cuenta demo pre-cargada. Sin registro, sin email.',
+      },
+      portfolioVsRadar: {
+        q: '¿Cuál es la diferencia entre Cartera y Radar?',
+        a: 'La Cartera es lo que realmente tienes — cantidades, precios medios, valor real. El Radar es tu lista de seguimiento — acciones que vigilas con precios objetivo opcionales. La misma acción puede estar en ambos.',
+      },
+    },
+    portfolioRadar: {
+      addHolding: {
+        q: '¿Cómo añado una posición?',
+        a: 'Ve a Cartera, busca la acción, haz clic en Añadir. Introduce la cantidad y el precio medio. Más tarde puedes añadir más acciones (el precio medio se actualiza automáticamente) o eliminar posiciones.',
+      },
+      multiCurrency: {
+        q: '¿Puedo seguir acciones en varias monedas?',
+        a: 'Sí. Cada posición se mantiene en su moneda de cotización. Configura una moneda preferida en Ajustes y convertimos los totales por moneda a un único total mostrado usando tipos de cambio diarios.',
+      },
+      yoc: {
+        q: '¿Qué significa "Yield on Cost"?',
+        a: 'Yield on Cost = dividendo anual por acción ÷ tu precio medio de compra × 100. Mide la rentabilidad que aseguraste cuando compraste, sin importar lo que haya hecho la cotización desde entonces.',
+      },
+      targetPrice: {
+        q: '¿Qué es un precio objetivo?',
+        a: 'Tu umbral personal de compra para una acción — el precio al que considerarías añadirla. Configúralo en una acción del Radar y verás la diferencia con el precio actual (por encima/por debajo) para detectar oportunidades.',
+      },
+      communityTarget: {
+        q: '¿De dónde sale el "precio objetivo medio de la comunidad"?',
+        a: 'Promediamos los precios objetivo configurados por todos los usuarios que siguen la misma acción. Para proteger los objetivos individuales, solo mostramos la media cuando al menos 3 usuarios han configurado uno.',
+      },
+      score: {
+        q: '¿Qué significa la puntuación de dividendo?',
+        a: 'Una puntuación de 0–10 que resume la salud del dividendo de una acción: payout ratio, crecimiento del dividendo, rentabilidad y consistencia. Más alto es mejor. 7+ es "Strong", 5–7 "Fair", por debajo de 5 "Weak".',
+      },
+    },
+    dividends: {
+      upcoming: {
+        q: '¿Cómo se calculan los próximos dividendos?',
+        a: 'Para cada posición sacamos del proveedor de datos la próxima fecha ex-dividendo y el importe esperado por acción, multiplicado por tu cantidad. El dashboard muestra los próximos 14 días.',
+      },
+      import: {
+        q: '¿Puedo importar dividendos desde mi bróker?',
+        a: 'Sí. En la página de Dividendos, haz clic en Importar. Sube un CSV de tu bróker; lo procesamos, te enseñamos una vista previa y confirmas antes de guardar nada.',
+      },
+      brokerSupport: {
+        q: '¿Qué brókeres están soportados en la importación?',
+        a: 'Actualmente Interactive Brokers y MyInvestor. Añadir un nuevo bróker significa escribir un parser — abre un issue en GitHub con un CSV de ejemplo y lo consideraremos.',
+      },
+      unsupportedBroker: {
+        q: '¿Y si mi bróker no está soportado?',
+        a: 'Añade los dividendos manualmente en la página de Dividendos. O abre un issue en GitHub pidiendo soporte para tu bróker — adjunta un CSV de ejemplo.',
+      },
+    },
+    ai: {
+      model: {
+        q: '¿Qué modelo de IA usáis?',
+        a: 'Actualmente usamos Claude de Anthropic (Haiku para resúmenes de acciones, Sonnet para análisis de cartera y radar). El servicio es agnóstico de proveedor y puede cambiarse sin afectar a la UI.',
+      },
+      limit: {
+        q: '¿Hay un límite de uso de IA?',
+        a: 'Los usuarios no admin tienen 3 peticiones de IA al día entre todas las funciones (análisis, resúmenes, chat de Telegram). Las llamadas a la IA cuestan dinero real; el límite mantiene el servicio gratis para todos.',
+      },
+      privacy: {
+        q: '¿Mis datos se envían al proveedor de IA?',
+        a: 'Solo los datos necesarios para el prompt — las acciones implicadas, tus objetivos, tus dividendos. Nunca enviamos tu email, contraseña ni nada fuera de la petición concreta. Los prompts no se retienen.',
+      },
+    },
+    pulse: {
+      what: {
+        q: '¿Qué es Pulse?',
+        a: 'Pulse es la comunidad de Quantic en pulse.quantic.es. Los usuarios pueden activar el compartir su cartera (posiciones + sectores) y/o su radar (lista + precios objetivo) bajo un slug público.',
+      },
+      whoSees: {
+        q: '¿Quién puede ver mi cartera compartida?',
+        a: 'Cualquiera con la URL. Las páginas de Pulse son públicamente accesibles sin cuenta. No compartas si no estás cómodo con eso — es opt-in justamente por este motivo.',
+      },
+      optOut: {
+        q: '¿Cómo dejo de compartir?',
+        a: 'Ajustes → Compartir en Pulse → desactiva el interruptor de la superficie que quieras dejar de compartir. Los datos se eliminan de Pulse inmediatamente.',
+      },
+    },
+    telegram: {
+      connect: {
+        q: '¿Cómo conecto Telegram?',
+        a: 'Ajustes → Conectar Telegram → haz clic en "Abrir el bot de Telegram". Pulsa Enviar en Telegram, vuelve aquí y haz clic en Actualizar. Tu cuenta de Telegram queda enlazada.',
+      },
+      what: {
+        q: '¿Qué le puedo preguntar al bot?',
+        a: 'Pregúntale cosas como "¿qué dividendos he recibido este mes?", "muéstrame mi radar", "¿hay ex-divs esta semana?". El bot responde usando tus datos reales a través de la IA.',
+      },
+    },
+    dataPrivacy: {
+      stockData: {
+        q: '¿De dónde vienen los datos de las acciones?',
+        a: 'Precios, dividendos, fechas ex-div y fundamentales vienen de Yahoo Finance (con Alpha Vantage como fallback). Los datos se cachean 1 hora para mantenernos dentro de los límites gratuitos.',
+      },
+      accuracy: {
+        q: '¿Cómo de precisos son los datos?',
+        a: 'Lo mejor posible. Las APIs externas a veces sirven datos desactualizados o incorrectos, especialmente el día de un ex-dividendo o justo después de un split. Verifica siempre contra el extracto oficial de tu bróker antes de actuar.',
+      },
+      sell: {
+        q: '¿Vendéis mis datos?',
+        a: 'No. Quantic no tiene publicidad, ni tracking de terceros, ni venta de datos. Somos un proyecto paralelo de un solo desarrollador, no una empresa de datos.',
+      },
+    },
   },
 
   // Home Page

--- a/app/frontend/pages/FaqPage.tsx
+++ b/app/frontend/pages/FaqPage.tsx
@@ -1,0 +1,146 @@
+import { useState } from 'react'
+import { ChevronDown, ExternalLink, HelpCircle } from 'lucide-react'
+import { useTranslation } from 'react-i18next'
+import { LazyMotion, domAnimation, m } from 'motion/react'
+import { Card, CardContent } from '@/components/ui/card'
+import { cn } from '@/lib/utils'
+import { fadeUp, staggerChildren, onceInView } from '../lib/motion'
+
+interface SectionDef {
+  key: string
+  items: string[]
+}
+
+// FAQ data — sections + items. Each item maps to two i18n keys:
+// `faq.<section>.<item>.q` (question) and `faq.<section>.<item>.a` (answer).
+// Keeping the structure declarative lets translators add/reorder items
+// without touching the page component.
+const SECTIONS: SectionDef[] = [
+  { key: 'gettingStarted', items: ['free', 'broker', 'tryWithoutSignup', 'portfolioVsRadar'] },
+  { key: 'portfolioRadar', items: ['addHolding', 'multiCurrency', 'yoc', 'targetPrice', 'communityTarget', 'score'] },
+  { key: 'dividends', items: ['upcoming', 'import', 'brokerSupport', 'unsupportedBroker'] },
+  { key: 'ai', items: ['model', 'limit', 'privacy'] },
+  { key: 'pulse', items: ['what', 'whoSees', 'optOut'] },
+  { key: 'telegram', items: ['connect', 'what'] },
+  { key: 'dataPrivacy', items: ['stockData', 'accuracy', 'sell'] },
+]
+
+const ISSUES_URL = 'https://github.com/fleveque/dividend-portfolio/issues'
+
+export function FaqPage() {
+  const { t } = useTranslation()
+
+  return (
+    <LazyMotion features={domAnimation}>
+      <div className="container mx-auto px-4 py-8 max-w-3xl space-y-10">
+        {/* Hero */}
+        <m.header
+          initial={{ opacity: 0, y: 12 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ duration: 0.4 }}
+          className="text-center"
+        >
+          <div className="mx-auto mb-4 inline-flex size-12 items-center justify-center rounded-2xl bg-gradient-emerald-cyan text-white shadow-md">
+            <HelpCircle className="size-6" />
+          </div>
+          <h1 className="text-3xl sm:text-4xl font-bold tracking-tight mb-2">
+            {t('faq.title')}
+          </h1>
+          <p className="text-muted-foreground text-base sm:text-lg max-w-xl mx-auto">
+            {t('faq.subtitle')}
+          </p>
+        </m.header>
+
+        {/* Sections */}
+        {SECTIONS.map((section) => (
+          <m.section
+            key={section.key}
+            variants={staggerChildren}
+            initial="hidden"
+            whileInView="visible"
+            viewport={onceInView}
+            className="space-y-3"
+          >
+            <m.h2
+              variants={fadeUp}
+              className="text-lg sm:text-xl font-bold tracking-tight flex items-center gap-2"
+            >
+              <span className="w-1 h-5 bg-foreground rounded-full" />
+              {t(`faq.sections.${section.key}`)}
+            </m.h2>
+
+            <m.ul variants={staggerChildren} className="space-y-2">
+              {section.items.map((item) => (
+                <m.li key={item} variants={fadeUp}>
+                  <FaqItem
+                    qKey={`faq.${section.key}.${item}.q`}
+                    aKey={`faq.${section.key}.${item}.a`}
+                  />
+                </m.li>
+              ))}
+            </m.ul>
+          </m.section>
+        ))}
+
+        {/* Not-found footer */}
+        <m.section
+          initial={{ opacity: 0, y: 12 }}
+          whileInView={{ opacity: 1, y: 0 }}
+          viewport={onceInView}
+          transition={{ duration: 0.4 }}
+          className="rounded-2xl border border-border bg-card p-6 text-center"
+        >
+          <p className="text-sm sm:text-base text-muted-foreground mb-3">
+            {t('faq.notFound.body')}
+          </p>
+          <a
+            href={ISSUES_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 text-sm font-medium text-emerald-700 dark:text-emerald-300 hover:underline"
+          >
+            {t('faq.notFound.cta')} <ExternalLink className="size-3.5" />
+          </a>
+        </m.section>
+      </div>
+    </LazyMotion>
+  )
+}
+
+interface FaqItemProps {
+  qKey: string
+  aKey: string
+}
+
+function FaqItem({ qKey, aKey }: FaqItemProps) {
+  const { t } = useTranslation()
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  return (
+    <Card className={cn('transition-colors', isExpanded && 'border-emerald-500/30')}>
+      <button
+        type="button"
+        onClick={() => setIsExpanded((v) => !v)}
+        className="w-full flex items-center justify-between gap-3 px-5 py-4 text-left cursor-pointer"
+        aria-expanded={isExpanded}
+      >
+        <span className="text-sm sm:text-base font-medium leading-snug">{t(qKey)}</span>
+        <ChevronDown
+          className={cn(
+            'size-4 shrink-0 text-muted-foreground transition-transform duration-200',
+            isExpanded && 'rotate-180'
+          )}
+        />
+      </button>
+      {isExpanded && (
+        <CardContent className="pt-0 pb-5 px-5">
+          <p className="text-sm text-muted-foreground leading-relaxed whitespace-pre-line">
+            {t(aKey)}
+          </p>
+        </CardContent>
+      )}
+    </Card>
+  )
+}
+
+export default FaqPage


### PR DESCRIPTION
## Why

Quantic now spans enough distinct concepts — Portfolio vs Radar vs Buy Plan, Pulse community sharing, Telegram bot, AI insights, multi-currency, dividend import — that visitors (especially pre-signup) hit "wait, what?" friction without a single canonical reference. The recent footer disclaimer (#177) addressed the legal angle; this PR addresses the curiosity angle.

## What

**New `/faq` page** at `app/frontend/pages/FaqPage.tsx`. Public route registered in `App.tsx` next to `/login` so both anonymous visitors and logged-in users get it. Inherits the existing Layout chrome automatically (header, language/theme toggles, disclaimer-bearing footer).

**Expand/collapse pattern** reuses `PortfolioInsights.tsx`'s `useState(isExpanded)` + `ChevronDown` approach — no `shadcn/accordion` install needed, keeps the dep surface flat.

**22 questions across 7 sections**, covering both audiences:

| Section | Questions |
|---|---|
| Getting started | free / broker connection / try without signup / portfolio vs radar |
| Portfolio & Radar | how to add / multi-currency / YoC / target price / community target / dividend score |
| Dividends | upcoming math / broker import / supported brokers / unsupported broker |
| AI insights | which model / usage limit / data privacy |
| Pulse | what is it / who sees / how to opt out |
| Telegram | how to connect / what to ask |
| Data & privacy | data source / accuracy / no data sales |

**Footer link** added next to the copyright line in `Layout.tsx`.

**Full en + es i18n** in the same commit — Spanish translations land alongside English, no lag.

**Motion** reuses the existing `lib/motion.ts` variants (`fadeUp`, `staggerChildren`, `onceInView`) so the page speaks the same motion language as the home redesign. `prefers-reduced-motion` honored via the global CSS guard.

## Out of scope (deferred)

- Search/filter
- Deep-linking via URL hash (`/faq#how-do-i-import`)
- "Was this helpful?" feedback
- Linking from in-app surfaces (e.g., a "?" next to "Yield on Cost" deep-linking to the FAQ entry)

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx vite build` — succeeds
- [ ] Manual: visit `/faq` logged out → all sections render, cards expand/collapse
- [ ] Manual: visit `/faq` logged in → same page, full chrome
- [ ] Manual: footer link works from any page
- [ ] Manual: switch to ES → all 22 Q+A render in Spanish
- [ ] Manual: reduced-motion → no jank
- [ ] Manual: 375px mobile → single column, taps clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)